### PR TITLE
feat: implemented Google Calendar integration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -88,4 +88,12 @@ if (secretPropsFile.exists()) {
     }
 }
 
+bootRun {
+    ['GOOGLE_CLIENT_ID', 'GOOGLE_CLIENT_SECRET'].each { key ->
+        if (project.hasProperty(key)) {
+            systemProperty key, project.property(key)
+        }
+    }
+}
+
 defaultTasks 'bootJar', 'build'

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/CalendarController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/CalendarController.java
@@ -1,0 +1,109 @@
+package ch.uzh.ifi.hase.soprafs26.controller;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.List;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import ch.uzh.ifi.hase.soprafs26.entity.User;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.CalendarConnectGetDTO;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.CalendarEventGetDTO;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.FreeSlotGetDTO;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.FreeSlotRequestDTO;
+import ch.uzh.ifi.hase.soprafs26.service.CalendarService;
+import ch.uzh.ifi.hase.soprafs26.service.UserService;
+import jakarta.servlet.http.HttpServletResponse;
+
+@RestController
+public class CalendarController {
+
+    private final CalendarService calendarService;
+    private final UserService userService;
+
+    CalendarController(CalendarService calendarService, UserService userService) {
+        this.calendarService = calendarService;
+        this.userService = userService;
+    }
+
+    /**
+     * Returns the Google OAuth2 URL the frontend should redirect to
+     */
+    @GetMapping("/users/{userId}/calendar/connect")
+    @ResponseStatus(HttpStatus.OK)
+    public CalendarConnectGetDTO getConnectUrl(@PathVariable Long userId,
+            @CookieValue(name = "token", required = true) String token) {
+
+        User requestingUser = userService.getUserByToken(token);
+        verifyOwnership(requestingUser.getId(), userId);
+
+        CalendarConnectGetDTO dto = new CalendarConnectGetDTO();
+        dto.setAuthUrl(calendarService.getConnectUrl(userId));
+        dto.setConnected(calendarService.isConnected(userId));
+        return dto;
+    }
+
+    /**
+     * OAuth2 redirect endpoint — for Google callbacks
+     */
+    @GetMapping("/calendar/callback")
+    public void handleOAuthCallback(@RequestParam String code, @RequestParam String state, HttpServletResponse response)
+            throws IOException {
+
+        Long userId = Long.parseLong(state);
+        calendarService.handleOAuthCallback(code, userId);
+        response.sendRedirect(calendarService.getFrontendRedirectUri() + "?calendarConnected=true");
+    }
+
+    /**
+     * Returns the users next 20 upcoming Calendar Events.
+     */
+    @GetMapping("/users/{userId}/calendar/events")
+    @ResponseStatus(HttpStatus.OK)
+    public List<CalendarEventGetDTO> getEvents(@PathVariable Long userId,
+            @CookieValue(name = "token", required = true) String token) {
+
+        User requestingUser = userService.getUserByToken(token);
+        verifyOwnership(requestingUser.getId(), userId);
+
+        return calendarService.getEvents(userId);
+    }
+
+    /**
+     * Finds time slots within the parameter window where all given users are free
+     */
+    @PostMapping("/users/{userId}/calendar/free-slots")
+    @ResponseStatus(HttpStatus.OK)
+    public List<FreeSlotGetDTO> findFreeSlots(@PathVariable Long userId, @RequestBody FreeSlotRequestDTO requestDTO,
+            @CookieValue(name = "token", required = true) String token) {
+
+        User requestingUser = userService.getUserByToken(token);
+        verifyOwnership(requestingUser.getId(), userId);
+
+        Instant from = Instant.parse(requestDTO.getFrom());
+        Instant to = Instant.parse(requestDTO.getTo());
+
+        return calendarService.findFreeSlots(requestDTO.getUserIds(), from, to);
+    }
+
+    /**
+     * Disconnects the user's Calendar by removing tokens.
+     */
+    @DeleteMapping("/users/{userId}/calendar/disconnect")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void disconnect(@PathVariable Long userId, @CookieValue(name = "token", required = true) String token) {
+
+        User requestingUser = userService.getUserByToken(token);
+        verifyOwnership(requestingUser.getId(), userId);
+
+        calendarService.disconnect(userId);
+    }
+
+    private void verifyOwnership(Long requestingUserId, Long targetUserId) {
+        if (!requestingUserId.equals(targetUserId)) {
+            throw new org.springframework.web.server.ResponseStatusException(HttpStatus.FORBIDDEN,
+                    "You can only access your own calendar");
+        }
+    }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/CalendarToken.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/CalendarToken.java
@@ -1,0 +1,102 @@
+package ch.uzh.ifi.hase.soprafs26.entity;
+
+import jakarta.persistence.*;
+import java.io.Serializable;
+import java.time.Instant;
+
+@Entity
+@Table(name = "calendar_tokens")
+public class CalendarToken implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private Long userId;
+
+    @Column(nullable = false, length = 2048)
+    private String accessToken;
+
+    @Column(length = 512)
+    private String refreshToken;
+
+    @Column
+    private Instant expiresAt;
+
+    @Column(nullable = false)
+    private Instant createdAt;
+
+    @Column(nullable = false)
+    private Instant updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        Instant now = Instant.now();
+        this.createdAt = now;
+        this.updatedAt = now;
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedAt = Instant.now();
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+
+    public void setUserId(Long userId) {
+        this.userId = userId;
+    }
+
+    public String getAccessToken() {
+        return accessToken;
+    }
+
+    public void setAccessToken(String accessToken) {
+        this.accessToken = accessToken;
+    }
+
+    public String getRefreshToken() {
+        return refreshToken;
+    }
+
+    public void setRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
+
+    public Instant getExpiresAt() {
+        return expiresAt;
+    }
+
+    public void setExpiresAt(Instant expiresAt) {
+        this.expiresAt = expiresAt;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Instant createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(Instant updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/CalendarTokenRepository.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/CalendarTokenRepository.java
@@ -1,0 +1,13 @@
+package ch.uzh.ifi.hase.soprafs26.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import ch.uzh.ifi.hase.soprafs26.entity.CalendarToken;
+
+@Repository("calendarTokenRepository")
+public interface CalendarTokenRepository extends JpaRepository<CalendarToken, Long> {
+    Optional<CalendarToken> findByUserId(Long userId);
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/CalendarConnectGetDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/CalendarConnectGetDTO.java
@@ -1,0 +1,22 @@
+package ch.uzh.ifi.hase.soprafs26.rest.dto;
+
+public class CalendarConnectGetDTO {
+    private String authUrl;
+    private boolean connected;
+
+    public String getAuthUrl() {
+        return authUrl;
+    }
+
+    public void setAuthUrl(String authUrl) {
+        this.authUrl = authUrl;
+    }
+
+    public boolean isConnected() {
+        return connected;
+    }
+
+    public void setConnected(boolean connected) {
+        this.connected = connected;
+    }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/CalendarEventGetDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/CalendarEventGetDTO.java
@@ -1,0 +1,67 @@
+package ch.uzh.ifi.hase.soprafs26.rest.dto;
+
+public class CalendarEventGetDTO {
+    private String id;
+    private String summary;
+    private String description;
+    private String location;
+    private String start;
+    private String end;
+    private boolean allDay;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getSummary() {
+        return summary;
+    }
+
+    public void setSummary(String summary) {
+        this.summary = summary;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getLocation() {
+        return location;
+    }
+
+    public void setLocation(String location) {
+        this.location = location;
+    }
+
+    public String getStart() {
+        return start;
+    }
+
+    public void setStart(String start) {
+        this.start = start;
+    }
+
+    public String getEnd() {
+        return end;
+    }
+
+    public void setEnd(String end) {
+        this.end = end;
+    }
+
+    public boolean isAllDay() {
+        return allDay;
+    }
+
+    public void setAllDay(boolean allDay) {
+        this.allDay = allDay;
+    }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/FreeSlotGetDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/FreeSlotGetDTO.java
@@ -1,0 +1,22 @@
+package ch.uzh.ifi.hase.soprafs26.rest.dto;
+
+public class FreeSlotGetDTO {
+    private String start;
+    private String end;
+
+    public String getStart() {
+        return start;
+    }
+
+    public void setStart(String start) {
+        this.start = start;
+    }
+
+    public String getEnd() {
+        return end;
+    }
+
+    public void setEnd(String end) {
+        this.end = end;
+    }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/FreeSlotRequestDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/FreeSlotRequestDTO.java
@@ -1,0 +1,33 @@
+package ch.uzh.ifi.hase.soprafs26.rest.dto;
+
+import java.util.List;
+
+public class FreeSlotRequestDTO {
+    private List<Long> userIds;
+    private String from;
+    private String to;
+
+    public List<Long> getUserIds() {
+        return userIds;
+    }
+
+    public void setUserIds(List<Long> userIds) {
+        this.userIds = userIds;
+    }
+
+    public String getFrom() {
+        return from;
+    }
+
+    public void setFrom(String from) {
+        this.from = from;
+    }
+
+    public String getTo() {
+        return to;
+    }
+
+    public void setTo(String to) {
+        this.to = to;
+    }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/CalendarService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/CalendarService.java
@@ -1,0 +1,335 @@
+package ch.uzh.ifi.hase.soprafs26.service;
+
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import ch.uzh.ifi.hase.soprafs26.entity.CalendarToken;
+import ch.uzh.ifi.hase.soprafs26.entity.User;
+import ch.uzh.ifi.hase.soprafs26.repository.CalendarTokenRepository;
+import ch.uzh.ifi.hase.soprafs26.repository.UserRepository;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.CalendarEventGetDTO;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.FreeSlotGetDTO;
+
+@Service
+@Transactional
+public class CalendarService {
+
+    private static final String GOOGLE_AUTH_URL = "https://accounts.google.com/o/oauth2/v2/auth";
+    private static final String GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token";
+    private static final String GOOGLE_CALENDAR_EVENTS_URL = "https://www.googleapis.com/calendar/v3/calendars/primary/events";
+    private static final String GOOGLE_FREEBUSY_URL = "https://www.googleapis.com/calendar/v3/freeBusy";
+    private static final String GOOGLE_CALENDAR_SCOPE = "https://www.googleapis.com/auth/calendar.readonly";
+
+    // Fixed issue of not mapping correct values
+    // source:
+    // https://developers.google.com/workspace/calendar/api/v3/reference/freebusy/query?_gl=1*9taivb*_up*MQ..*_ga*MjA0Nzg1OTIzMC4xNzc2NjI3NDI2*_ga_SM8HXJ53K2*czE3NzY2Mjc0MjYkbzEkZzAkdDE3NzY2Mjc0MjYkajYwJGwwJGgw
+    @Value("${google.calendar.client-id:}")
+    private String clientId;
+
+    @Value("${google.calendar.client-secret:}")
+    private String clientSecret;
+
+    @Value("${google.calendar.redirect-uri}")
+    private String redirectUri;
+
+    @Value("${google.calendar.frontend-redirect-uri}")
+    private String frontendRedirectUri;
+
+    private final CalendarTokenRepository calendarTokenRepository;
+    private final UserRepository userRepository;
+
+    CalendarService(CalendarTokenRepository calendarTokenRepository, UserRepository userRepository) {
+        this.calendarTokenRepository = calendarTokenRepository;
+        this.userRepository = userRepository;
+    }
+
+    public String getConnectUrl(Long userId) {
+        return GOOGLE_AUTH_URL
+                + "?client_id=" + encode(clientId)
+                + "&redirect_uri=" + encode(redirectUri)
+                + "&response_type=code"
+                + "&scope=" + encode(GOOGLE_CALENDAR_SCOPE)
+                + "&access_type=offline"
+                + "&prompt=consent"
+                + "&state=" + userId;
+    }
+
+    public void handleOAuthCallback(String code, Long userId) {
+        String body = "code=" + encode(code)
+                + "&client_id=" + encode(clientId)
+                + "&client_secret=" + encode(clientSecret)
+                + "&redirect_uri=" + encode(redirectUri)
+                + "&grant_type=authorization_code";
+
+        JSONObject tokens = postToTokenEndpoint(body);
+
+        String accessToken = tokens.getString("access_token");
+        String refreshToken = tokens.optString("refresh_token", null);
+        int expiresIn = tokens.optInt("expires_in", 3600);
+
+        CalendarToken calendarToken = calendarTokenRepository.findByUserId(userId).orElseGet(CalendarToken::new);
+        calendarToken.setUserId(userId);
+        calendarToken.setAccessToken(accessToken);
+        calendarToken.setExpiresAt(Instant.now().plusSeconds(expiresIn));
+
+        if (refreshToken != null) {
+            calendarToken.setRefreshToken(refreshToken);
+        }
+
+        calendarTokenRepository.save(calendarToken);
+    }
+
+    /** Returns true when the user has a stored Google Calendar token. */
+    public boolean isConnected(Long userId) {
+        return calendarTokenRepository.findByUserId(userId).isPresent();
+    }
+
+    /** Removes stored Google Calendar tokens for the user. */
+    public void disconnect(Long userId) {
+        calendarTokenRepository.findByUserId(userId).ifPresent(calendarTokenRepository::delete);
+    }
+
+    public List<CalendarEventGetDTO> getEvents(Long userId) {
+        CalendarToken token = getValidToken(userId);
+
+        String url = GOOGLE_CALENDAR_EVENTS_URL
+                + "?timeMin=" + encode(Instant.now().toString())
+                + "&maxResults=20"
+                + "&orderBy=startTime"
+                + "&singleEvents=true";
+
+        try {
+            HttpClient client = HttpClient.newHttpClient();
+            HttpRequest request = HttpRequest.newBuilder().uri(URI.create(url))
+                    .header("Authorization", "Bearer " + token.getAccessToken())
+                    .GET()
+                    .build();
+
+            HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+            if (response.statusCode() != 200) {
+                throw new ResponseStatusException(HttpStatus.BAD_GATEWAY,
+                        "Google Calendar API error: " + response.statusCode());
+            }
+
+            return parseEvents(response.body());
+
+        } catch (Exception e) {
+            throw new ResponseStatusException(HttpStatus.BAD_GATEWAY, "Failed to fetch calendar events");
+        }
+    }
+
+    public List<FreeSlotGetDTO> findFreeSlots(List<Long> userIds, Instant from, Instant to) {
+        if (userIds == null || userIds.isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "userIds must not be empty");
+        }
+
+        JSONArray items = new JSONArray();
+        for (Long userId : userIds) {
+            User user = userRepository.findById(userId)
+                    .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found: " + userId));
+
+            JSONObject item = new JSONObject();
+            item.put("id", user.getEmail());
+            items.put(item);
+        }
+
+        JSONObject requestBody = new JSONObject();
+        requestBody.put("timeMin", from.toString());
+        requestBody.put("timeMax", to.toString());
+        requestBody.put("items", items);
+
+        CalendarToken token = getValidToken(userIds.get(0));
+
+        try {
+            HttpClient client = HttpClient.newHttpClient();
+            HttpRequest request = HttpRequest.newBuilder().uri(URI.create(GOOGLE_FREEBUSY_URL))
+                    .header("Authorization", "Bearer " + token.getAccessToken())
+                    .header("Content-Type", "application/json")
+                    .POST(HttpRequest.BodyPublishers.ofString(requestBody.toString()))
+                    .build();
+
+            HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+            if (response.statusCode() != 200) {
+                throw new ResponseStatusException(HttpStatus.BAD_GATEWAY,
+                        "Google FreeBusy API error: " + response.statusCode());
+            }
+
+            return computeFreeSlots(response.body(), from, to);
+
+        } catch (Exception e) {
+            throw new ResponseStatusException(HttpStatus.BAD_GATEWAY, "Failed to query free/busy data");
+        }
+    }
+
+    public String getFrontendRedirectUri() {
+        return frontendRedirectUri;
+    }
+
+    // #region Helpers
+
+    private CalendarToken getValidToken(Long userId) {
+        CalendarToken token = calendarTokenRepository.findByUserId(userId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED,
+                        "Google Calendar not connected for this user"));
+
+        // Refresh 60 seconds before expiry
+        if (token.getExpiresAt() != null && Instant.now().isAfter(token.getExpiresAt().minusSeconds(60))) {
+            token = refreshAccessToken(token);
+        }
+        return token;
+    }
+
+    private CalendarToken refreshAccessToken(CalendarToken token) {
+        if (token.getRefreshToken() == null) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED,
+                    "No refresh token stored. Please reconnect Google Calendar.");
+        }
+
+        String body = "grant_type=refresh_token"
+                + "&refresh_token=" + encode(token.getRefreshToken())
+                + "&client_id=" + encode(clientId)
+                + "&client_secret=" + encode(clientSecret);
+
+        JSONObject response = postToTokenEndpoint(body);
+
+        token.setAccessToken(response.getString("access_token"));
+        token.setExpiresAt(Instant.now().plusSeconds(response.optInt("expires_in", 3600)));
+
+        return calendarTokenRepository.save(token);
+    }
+
+    private JSONObject postToTokenEndpoint(String formBody) {
+        try {
+            HttpClient client = HttpClient.newHttpClient();
+            HttpRequest request = HttpRequest.newBuilder().uri(URI.create(GOOGLE_TOKEN_URL))
+                    .header("Content-Type", "application/x-www-form-urlencoded")
+                    .POST(HttpRequest.BodyPublishers.ofString(formBody))
+                    .build();
+
+            HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+
+            if (response.statusCode() != 200) {
+                throw new ResponseStatusException(HttpStatus.BAD_GATEWAY,
+                        "Google token endpoint error: " + response.body());
+            }
+            return new JSONObject(response.body());
+
+        } catch (Exception e) {
+            throw new ResponseStatusException(HttpStatus.BAD_GATEWAY,
+                    "Failed to get Google token endpoint");
+        }
+    }
+
+    private List<CalendarEventGetDTO> parseEvents(String json) {
+        JSONObject root = new JSONObject(json);
+        JSONArray itemsArray = root.optJSONArray("items");
+
+        List<CalendarEventGetDTO> events = new ArrayList<>();
+        if (itemsArray == null)
+            return events;
+
+        for (int i = 0; i < itemsArray.length(); i++) {
+
+            JSONObject item = itemsArray.getJSONObject(i);
+            CalendarEventGetDTO dto = new CalendarEventGetDTO();
+
+            dto.setId(item.optString("id", ""));
+            dto.setSummary(item.optString("summary", "Empty"));
+            dto.setDescription(item.optString("description", ""));
+            dto.setLocation(item.optString("location", ""));
+
+            JSONObject startObj = item.optJSONObject("start");
+            JSONObject endObj = item.optJSONObject("end");
+
+            if (startObj != null) {
+                if (startObj.has("dateTime")) {
+                    dto.setStart(startObj.getString("dateTime"));
+                    dto.setAllDay(false);
+                } else {
+                    dto.setStart(startObj.optString("date", ""));
+                    dto.setAllDay(true);
+                }
+            }
+            if (endObj != null) {
+                dto.setEnd(endObj.has("dateTime") ? endObj.getString("dateTime") : endObj.optString("date", ""));
+            }
+
+            events.add(dto);
+        }
+        return events;
+    }
+
+    /**
+     * maps the free time slots within from - to
+     */
+    private List<FreeSlotGetDTO> computeFreeSlots(String json, Instant from, Instant to) {
+        JSONObject root = new JSONObject(json);
+        JSONObject calendars = root.optJSONObject("calendars");
+
+        List<Instant[]> busyIntervals = new ArrayList<>();
+
+        if (calendars != null) {
+            for (String email : calendars.keySet()) {
+                JSONArray busy = calendars.getJSONObject(email).optJSONArray("busy");
+                if (busy == null)
+                    continue;
+                for (int i = 0; i < busy.length(); i++) {
+                    JSONObject interval = busy.getJSONObject(i);
+                    busyIntervals.add(new Instant[] {
+                            Instant.parse(interval.getString("start")),
+                            Instant.parse(interval.getString("end"))
+                    });
+                }
+            }
+        }
+
+        busyIntervals.sort((a, b) -> a[0].compareTo(b[0]));
+
+        List<FreeSlotGetDTO> freeSlots = new ArrayList<>();
+        Instant cursor = from;
+
+        for (Instant[] busy : busyIntervals) {
+            if (busy[0].isAfter(cursor)) {
+                FreeSlotGetDTO slot = new FreeSlotGetDTO();
+                slot.setStart(cursor.toString());
+                slot.setEnd(busy[0].toString());
+                freeSlots.add(slot);
+            }
+            if (busy[1].isAfter(cursor)) {
+                cursor = busy[1];
+            }
+        }
+
+        if (cursor.isBefore(to)) {
+            FreeSlotGetDTO slot = new FreeSlotGetDTO();
+            slot.setStart(cursor.toString());
+            slot.setEnd(to.toString());
+            freeSlots.add(slot);
+        }
+
+        return freeSlots;
+    }
+
+    private String encode(String value) {
+        return URLEncoder.encode(value, StandardCharsets.UTF_8);
+    }
+}
+
+// #endregion

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,4 +1,5 @@
 server.port=8080
+server.servlet.context-path=/api
 
 # Enabling the H2-Console (local and remote)
 spring.h2.console.enabled=true
@@ -14,3 +15,10 @@ spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
 # You can find your h2-console at: http://localhost:8080/h2-console/
 # If you changed the server.port, you must also change it in the URL
 # The credentials to log in to the h2 Driver are defined above. Be aware that the h2-console is only accessible when the server is running.
+
+# Google Calendar OAuth2
+# Set environment variables or in local.properties
+google.calendar.client-id=${GOOGLE_CLIENT_ID:}
+google.calendar.client-secret=${GOOGLE_CLIENT_SECRET:}
+google.calendar.redirect-uri=${GOOGLE_REDIRECT_URI:http://localhost:8080/api/calendar/callback}
+google.calendar.frontend-redirect-uri=${FRONTEND_REDIRECT_URI:http://localhost:3000}


### PR DESCRIPTION
Integrated Google Calendar so users can connect their calendar and the server can schedule boss raids based on the free entries


## Changes

- OAuth2 connect/disconnect flow with automatic token refresh
- `GET /users/{userId}/calendar/events` -> fetch next 20 upcoming events
- `POST /users/{userId}/calendar/free-slots` -> find free windows across multiple users via Google FreeBusy API
- Redirect uris assigned by `GOOGLE_REDIRECT_URI` / `FRONTEND_REDIRECT_URI` env vars

closes #104 