### PR TITLE
feat: implement achievement system with streak tracking and habit reset scheduler. closes #44 #45 #46 #58

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/constant/AchievementKey.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/constant/AchievementKey.java
@@ -1,0 +1,11 @@
+package ch.uzh.ifi.hase.soprafs26.constant;
+
+public enum AchievementKey {
+    FIRST_HABIT,
+    STREAK_3,
+    STREAK_7,
+    //FIRST_BOSS, once boss raid complete
+    STRENGTH_25,
+    INTELLIGENCE_25,
+    RESILIENCE_25
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/AchievementController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/AchievementController.java
@@ -1,0 +1,43 @@
+package ch.uzh.ifi.hase.soprafs26.controller;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import ch.uzh.ifi.hase.soprafs26.rest.dto.AchievementGetDTO;
+import ch.uzh.ifi.hase.soprafs26.rest.mapper.DTOMapper;
+import ch.uzh.ifi.hase.soprafs26.service.AchievementService;
+import ch.uzh.ifi.hase.soprafs26.service.UserService;
+
+@RestController
+public class AchievementController {
+
+    private final AchievementService achievementService;
+    private final UserService userService;
+
+    AchievementController(AchievementService achievementService, UserService userService) {
+        this.achievementService = achievementService;
+        this.userService = userService;
+    }
+
+    @GetMapping("/users/{userId}/achievements")
+    @ResponseStatus(HttpStatus.OK)
+    @ResponseBody
+    public List<AchievementGetDTO> getAchievements(
+            @PathVariable Long userId,
+            @CookieValue(name = "token", required = true) String token) {
+
+        userService.getUserByToken(token);
+
+        return achievementService.getAchievementsForUser(userId).stream()
+                .map(DTOMapper.INSTANCE::convertEntityToAchievementGetDTO)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/Achievement.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/Achievement.java
@@ -1,0 +1,67 @@
+package ch.uzh.ifi.hase.soprafs26.entity;
+
+import ch.uzh.ifi.hase.soprafs26.constant.AchievementKey;
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "achievements")
+public class Achievement {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, unique = true)
+    private AchievementKey key;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private String description;
+
+    @Column(nullable = false)
+    private String icon;
+
+    //getters and setters
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public AchievementKey getKey() {
+        return key;
+    }
+
+    public void setKey(AchievementKey key) {
+        this.key = key;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getIcon() {
+        return icon;
+    }
+
+    public void setIcon(String icon) {
+        this.icon = icon;
+    }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/Achievement.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/Achievement.java
@@ -12,7 +12,7 @@ public class Achievement {
     private Long id;
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false, unique = true)
+    @Column(name = "achievement_key", nullable = false, unique = true)
     private AchievementKey key;
 
     @Column(nullable = false)

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/CharacterAchievement.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/CharacterAchievement.java
@@ -1,0 +1,63 @@
+package ch.uzh.ifi.hase.soprafs26.entity;
+
+import jakarta.persistence.*;
+import java.time.Instant;
+
+@Entity
+@Table(name = "character_achievements", uniqueConstraints = @UniqueConstraint(columnNames = { "character_id",
+        "achievement_id" }))
+public class CharacterAchievement {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "character_id", nullable = false)
+    private Character character;
+
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "achievement_id", nullable = false)
+    private Achievement achievement;
+
+    @Column(nullable = false)
+    private Instant earnedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        this.earnedAt = Instant.now();
+    }
+
+    // getters and setters
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Character getCharacter() {
+        return character;
+    }
+
+    public void setCharacter(Character character) {
+        this.character = character;
+    }
+
+    public Achievement getAchievement() {
+        return achievement;
+    }
+
+    public void setAchievement(Achievement achievement) {
+        this.achievement = achievement;
+    }
+
+    public Instant getEarnedAt() {
+        return earnedAt;
+    }
+
+    public void setEarnedAt(Instant earnedAt) {
+        this.earnedAt = earnedAt;
+    }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/AchievementRepository.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/AchievementRepository.java
@@ -1,0 +1,12 @@
+package ch.uzh.ifi.hase.soprafs26.repository;
+
+import ch.uzh.ifi.hase.soprafs26.constant.AchievementKey;
+import ch.uzh.ifi.hase.soprafs26.entity.Achievement;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import java.util.Optional;
+
+@Repository
+public interface AchievementRepository extends JpaRepository<Achievement, Long> {
+    Optional<Achievement> findByKey(AchievementKey key);
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/CharacterAchievementRepository.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/CharacterAchievementRepository.java
@@ -1,0 +1,15 @@
+// CharacterAchievementRepository.java
+package ch.uzh.ifi.hase.soprafs26.repository;
+
+import ch.uzh.ifi.hase.soprafs26.entity.Character;
+import ch.uzh.ifi.hase.soprafs26.entity.Achievement;
+import ch.uzh.ifi.hase.soprafs26.entity.CharacterAchievement;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import java.util.List;
+
+@Repository
+public interface CharacterAchievementRepository extends JpaRepository<CharacterAchievement, Long> {
+    List<CharacterAchievement> findByCharacter(Character character);
+    boolean existsByCharacterAndAchievement(Character character, Achievement achievement);
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/HabitRepository.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/HabitRepository.java
@@ -4,11 +4,13 @@ import ch.uzh.ifi.hase.soprafs26.entity.Habit;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.time.Instant;
 import java.util.List;
 
 @Repository("habitRepository")
 public interface HabitRepository extends JpaRepository<Habit, Long> {
-    
-    List<Habit> findByUserId(Long userId);
 
+    List<Habit> findByUserId(Long userId);
+    List<Habit> findByCompletedFalseAndDueAtBefore(Instant now);
+    List<Habit> findByCompletedTrueAndDueAtBefore(Instant now);
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/AchievementGetDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/AchievementGetDTO.java
@@ -1,0 +1,62 @@
+package ch.uzh.ifi.hase.soprafs26.rest.dto;
+
+import java.time.Instant;
+import ch.uzh.ifi.hase.soprafs26.constant.AchievementKey;
+
+public class AchievementGetDTO {
+
+    private Long id;
+    private AchievementKey key;
+    private String name;
+    private String description;
+    private String icon;
+    private Instant earnedAt;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public AchievementKey getKey() {
+        return key;
+    }
+
+    public void setKey(AchievementKey key) {
+        this.key = key;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getIcon() {
+        return icon;
+    }
+
+    public void setIcon(String icon) {
+        this.icon = icon;
+    }
+
+    public Instant getEarnedAt() {
+        return earnedAt;
+    }
+
+    public void setEarnedAt(Instant earnedAt) {
+        this.earnedAt = earnedAt;
+    }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/mapper/DTOMapper.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/mapper/DTOMapper.java
@@ -7,10 +7,12 @@ import org.mapstruct.factory.Mappers;
 
 import ch.uzh.ifi.hase.soprafs26.entity.BossRaid;
 import ch.uzh.ifi.hase.soprafs26.entity.Character;
+import ch.uzh.ifi.hase.soprafs26.entity.CharacterAchievement;
 import ch.uzh.ifi.hase.soprafs26.entity.Group;
 import ch.uzh.ifi.hase.soprafs26.entity.Habit;
 import ch.uzh.ifi.hase.soprafs26.entity.Todo;
 import ch.uzh.ifi.hase.soprafs26.entity.User;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.AchievementGetDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.CharacterGetDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.GroupGetDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.GroupPostDTO;
@@ -114,6 +116,13 @@ public interface DTOMapper {
 	@Mapping(source = "createdAt", target = "createdAt")
 	@Mapping(source = "users", target = "users")
 	GroupGetDTO convertEntityToGroupGetDTO(Group group);
+
+    @Mapping(source = "achievement.key", target = "key")
+    @Mapping(source = "achievement.name", target = "name")
+    @Mapping(source = "achievement.description", target = "description")
+    @Mapping(source = "achievement.icon", target = "icon")
+    @Mapping(source = "earnedAt", target = "earnedAt")
+    AchievementGetDTO convertEntityToAchievementGetDTO(CharacterAchievement characterAchievement);
 
     @Mapping(source = "name", target = "name")
     @Mapping(source = "durationSeconds", target = "durationSeconds")

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/AchievementService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/AchievementService.java
@@ -1,0 +1,115 @@
+package ch.uzh.ifi.hase.soprafs26.service;
+
+import ch.uzh.ifi.hase.soprafs26.entity.Character;
+import ch.uzh.ifi.hase.soprafs26.constant.AchievementKey;
+import ch.uzh.ifi.hase.soprafs26.entity.*;
+import ch.uzh.ifi.hase.soprafs26.repository.*;
+import jakarta.annotation.PostConstruct;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional
+public class AchievementService {
+
+    private final Logger log = LoggerFactory.getLogger(AchievementService.class);
+
+    private final AchievementRepository achievementRepository;
+    private final CharacterAchievementRepository characterAchievementRepository;
+    private final CharacterRepository characterRepository;
+
+    public AchievementService(AchievementRepository achievementRepository,
+            CharacterAchievementRepository characterAchievementRepository,
+            CharacterRepository characterRepository) {
+        this.achievementRepository = achievementRepository;
+        this.characterAchievementRepository = characterAchievementRepository;
+        this.characterRepository = characterRepository;
+    }
+
+    // seed all achievements into DB on startup if they don't exist yet 
+    @PostConstruct
+    public void seedAchievements() {
+        seed(AchievementKey.FIRST_HABIT, "Baby Steps", "Complete your first habit", "first_habit");
+        seed(AchievementKey.STREAK_3, "On a Roll", "Maintain a 3-day streak on any habit", "streak_3");
+        seed(AchievementKey.STREAK_7, "Unstoppable", "Maintain a 7-day streak on any habit", "streak_7");
+        // seed(AchievementKey.FIRST_BOSS, "Ready for Battle", "Help defeat your first
+        // bossraid", "first_boss");
+        seed(AchievementKey.STRENGTH_25, "Emerging Warrior", "Reach 25 Strength", "strength_25");
+        seed(AchievementKey.INTELLIGENCE_25, "Sharp Mind", "Reach 25 Intelligence", "intelligence_25");
+        seed(AchievementKey.RESILIENCE_25, "Iron Skin", "Reach 25 Resilience", "resilience_25");
+    }
+
+    private void seed(AchievementKey key, String name, String description, String icon) {
+        if (achievementRepository.findByKey(key).isEmpty()) {
+            Achievement a = new Achievement();
+            a.setKey(key);
+            a.setName(name);
+            a.setDescription(description);
+            a.setIcon(icon);
+            achievementRepository.save(a);
+            log.info("Seeded achievement: {}", key);
+        }
+    }
+
+    public void checkHabitAchievements(Long userId, int currentStreak) {
+        Character character = characterRepository.findByUserId(userId);
+        if (character == null)
+            return;
+        award(character, AchievementKey.FIRST_HABIT);
+
+        if (currentStreak >= 3) {
+            award(character, AchievementKey.STREAK_3);
+        }
+        if (currentStreak >= 7) {
+            award(character, AchievementKey.STREAK_7);
+        }
+    }
+
+    /*
+     * boss raids not complete yet
+     * 
+     * public void checkRaidAchievements(List<Long> participantUserIds) {
+     * for (Long userId : participantUserIds) {
+     * Character character = characterRepository.findByUserId(userId);
+     * if (character == null)
+     * continue;
+     * award(character, AchievementKey.FIRST_BOSS);
+     * }
+     * }
+     */
+    public void checkStatAchievements(Long userId, AchievementKey key, int newStatValue) {
+        if (newStatValue < 25)
+            return;
+        Character character = characterRepository.findByUserId(userId);
+        if (character == null)
+            return;
+        award(character, key);
+    }
+
+    // awards an achievement if the character hasn't earned it yet
+    private void award(Character character, AchievementKey key) {
+        Achievement achievement = achievementRepository.findByKey(key)
+                .orElse(null);
+        if (achievement == null)
+            return;
+
+        if (!characterAchievementRepository.existsByCharacterAndAchievement(character, achievement)) {
+            CharacterAchievement characterAchievement = new CharacterAchievement();
+            characterAchievement.setCharacter(character);
+            characterAchievement.setAchievement(achievement);
+            characterAchievementRepository.save(characterAchievement);
+            log.info("Achievement '{}' awarded to character {}", key, character.getId());
+        }
+    }
+
+    public List<CharacterAchievement> getAchievementsForUser(Long userId) {
+        Character character = characterRepository.findByUserId(userId);
+        if (character == null)
+            return List.of();
+        return characterAchievementRepository.findByCharacter(character);
+    }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/CharacterService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/CharacterService.java
@@ -2,12 +2,13 @@ package ch.uzh.ifi.hase.soprafs26.service;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 
+import ch.uzh.ifi.hase.soprafs26.constant.AchievementKey;
 import ch.uzh.ifi.hase.soprafs26.constant.HabitCategory;
 import ch.uzh.ifi.hase.soprafs26.entity.Character;
 import ch.uzh.ifi.hase.soprafs26.entity.User;
@@ -19,9 +20,12 @@ public class CharacterService {
 
     private final Logger log = LoggerFactory.getLogger(CharacterService.class);
     private final CharacterRepository characterRepository;
+    private final AchievementService achievementService;
 
-    public CharacterService(@Qualifier("characterRepository") CharacterRepository characterRepository) {
+    public CharacterService(CharacterRepository characterRepository, @Lazy AchievementService achievementService) {
         this.characterRepository = characterRepository;
+        this.achievementService = achievementService;
+
     }
 
     public Character createCharacter(User user) {
@@ -69,7 +73,19 @@ public class CharacterService {
         // level up and stats are handled in Character.java
         character.addExperience(finalXp);
         character.increaseStat(category);
-
+        // map habit category to respective achivement key
+        AchievementKey statKey = switch (category) {
+            case PHYSICAL -> AchievementKey.STRENGTH_25;
+            case COGNITIVE -> AchievementKey.INTELLIGENCE_25;
+            case EMOTIONAL -> AchievementKey.RESILIENCE_25;
+        };
+        // read updated stat value for achievement awarding
+        int newStat = switch (category) {
+            case PHYSICAL -> character.getStrength();
+            case COGNITIVE -> character.getIntelligence();
+            case EMOTIONAL -> character.getResilience();
+        };
+        achievementService.checkStatAchievements(userId, statKey, newStat);
         characterRepository.save(character);
 
         log.debug("Awarded {} XP (base: {}, multiplier: {}) to user {}",

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/HabitScheduler.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/HabitScheduler.java
@@ -1,0 +1,20 @@
+package ch.uzh.ifi.hase.soprafs26.service;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+public class HabitScheduler {
+
+    private final HabitService habitService;
+
+    HabitScheduler(HabitService habitService) {
+        this.habitService = habitService;
+    }
+
+    // resets completed flag for new periods and breaks overdue streaks
+    @Scheduled(fixedDelay = 60 * 1000) //runs every minute
+    public void resetOverdueHabits() {
+        habitService.resetOverdueHabits();
+    }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/HabitService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/HabitService.java
@@ -20,8 +20,7 @@ import ch.uzh.ifi.hase.soprafs26.repository.HabitRepository;
 import ch.uzh.ifi.hase.soprafs26.repository.UserRepository;
 
 @Service
-@Transactional // ensures DB data integrity for habit completion & awarding XP
-               // -> rolls back if anyhting fails
+@Transactional
 public class HabitService {
     private final Logger log = LoggerFactory.getLogger(HabitService.class);
 
@@ -30,17 +29,20 @@ public class HabitService {
     private final UserRepository userRepository;
     private final CharacterService characterService;
     private final HabitCompletionEventRepository completionEventRepository;
+    private final AchievementService achievementService;
 
     public HabitService(WeatherService weatherService,
             HabitRepository habitRepository,
             UserRepository userRepository,
             CharacterService characterService,
-            HabitCompletionEventRepository completionEventRepository) {
+            HabitCompletionEventRepository completionEventRepository,
+            AchievementService achievementService) {
         this.weatherService = weatherService;
         this.habitRepository = habitRepository;
         this.userRepository = userRepository;
         this.characterService = characterService;
         this.completionEventRepository = completionEventRepository;
+        this.achievementService = achievementService;
     }
 
     // ============================== weather ==============================
@@ -78,21 +80,24 @@ public class HabitService {
         }
 
         habit.complete();
-        habit.setStreak(habit.getStreak() + 1);
+        if (isStreakContinued(habit)) {
+            habit.setStreak(habit.getStreak() + 1);
+        } else {
+            habit.setStreak(1); // reset streak
+        }
         habit.setLastCompletedAt(Instant.now());
         habitRepository.save(habit);
+        achievementService.checkHabitAchievements(userId, habit.getStreak());
 
         if (habit.getPositive()) {
-            // positive habit -> award XP + update stat 
+            // positive habit -> award XP + update stat
             int baseXp = characterService.calculateBaseXp(habit.getWeight());
             double weatherMultiplier = getWeatherMultiplierSafely(habit.getCategory());
             int weatherCode = getWeatherCodeSafely();
-            int finalXp = characterService.awardXp(
-                    userId, habit.getCategory(), baseXp, weatherMultiplier);
+            int finalXp = characterService.awardXp(userId, habit.getCategory(), baseXp, weatherMultiplier);
 
             // record positive habit completion with XP details
-            recordCompletionEvent(habit, getUserOrThrow(userId),
-                    baseXp, finalXp, weatherMultiplier, weatherCode);
+            recordCompletionEvent(habit, getUserOrThrow(userId), baseXp, finalXp, weatherMultiplier, weatherCode);
         } else {
             // negative habit -> health penalty only, no XP + no stat increase
             characterService.applyNegativeHabitPenalty(userId, habit.getWeight());
@@ -103,6 +108,47 @@ public class HabitService {
         }
 
         return habit;
+    }
+
+    private boolean isStreakContinued(Habit habit) {
+        if (habit.getLastCompletedAt() == null) {
+            return false; // first ever completion
+        }
+
+        Instant last = habit.getLastCompletedAt();
+        Instant now = Instant.now();
+
+        long maxGapSeconds = switch (habit.getFrequency()) {
+            case DAILY -> 2L * 24 * 3600; // 1 day + 1 buffer day
+            case WEEKLY -> 8L * 24 * 3600; // 7 days + 1 buffer day
+            case MONTHLY -> 32L * 24 * 3600; // 31 days + 1 buffer day
+        };
+
+        return now.getEpochSecond() - last.getEpochSecond() <= maxGapSeconds;
+    }
+
+    public void resetOverdueHabits() {
+        Instant now = Instant.now();
+        List<Habit> overdueHabits = habitRepository.findByCompletedFalseAndDueAtBefore(now);
+
+        for (Habit habit : overdueHabits) {
+            // habit not completed before due date -> break streak
+            habit.setStreak(0);
+            // push due date forward by one period so it becomes active again
+            habit.setDueAt(calculateDueDate(habit));
+            habitRepository.save(habit);
+            log.debug("Streak reset for overdue habit '{}'", habit.getTitle());
+        }
+
+        // reset the completed flag for habits that are past due but were completed
+        List<Habit> completedPastDue = habitRepository.findByCompletedTrueAndDueAtBefore(now);
+        for (Habit habit : completedPastDue) {
+            habit.setCompleted(false);
+            habit.setCompletedAt(null);
+            habit.setDueAt(calculateDueDate(habit));
+            habitRepository.save(habit);
+            log.debug("Reset completed habit '{}' for new period", habit.getTitle());
+        }
     }
 
     public void deleteHabit(Long habitId, Long userId) {
@@ -116,7 +162,6 @@ public class HabitService {
     }
 
     // helper methods
-
     private void recordCompletionEvent(Habit habit, User user,
             int baseXp, int multipliedXp,
             double weatherMultiplier, int weatherCode) {

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/CharacterServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/CharacterServiceTest.java
@@ -20,6 +20,9 @@ public class CharacterServiceTest {
     @Mock
     private CharacterRepository characterRepository;
 
+    @Mock
+    private AchievementService achievementService;
+
     @InjectMocks
     private CharacterService characterService;
 

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/HabitServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/HabitServiceTest.java
@@ -27,6 +27,8 @@ import static org.mockito.Mockito.*;
 public class HabitServiceTest {
 
     @Mock
+    private AchievementService achievementService;
+    @Mock
     private WeatherService weatherService;
     @Mock
     private HabitRepository habitRepository;


### PR DESCRIPTION
implemented backend achievement logic tied to the character with new enum, entity, service, controller, repo and DTO. 

- resets streak to 0 when user misses deadline via background habit scheduler that runs every minute -> closes #44 
- achievements are awarded automatically when milestones are reached (habit streak, character stats and later also boss raids) -> closes #45 
- store earned achievements,  is now related to character and not to user in DB (user only for authentication, credentials etc.). CharacterAchievement entity persists to character_achievements table -> closes #46 
- "findByCompletedFalseAndDueAtBefore(now)"  detects every habit not completed before deadline, habit scheduler calls this every 60 seconds -> closes #58 
