### PR TITLE
moved away from basepath for backend calls

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -19,6 +19,6 @@ network:
 env_variables:
   GOOGLE_CLIENT_ID: ""
   GOOGLE_CLIENT_SECRET: ""
-  GOOGLE_REDIRECT_URI: "https://api.bettertogeter.ch/api/calendar/callback"
+  GOOGLE_REDIRECT_URI: "https://api.bettertogeter.ch/calendar/callback"
   FRONTEND_REDIRECT_URI: "https://bettertogeter.ch/"
   APP_COOKIE_DOMAIN: ".bettertogeter.ch"

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,4 @@
 server.port=8080
-server.servlet.context-path=/api
 server.forward-headers-strategy=FRAMEWORK
 
 # Auth cookie Domain (empty in dev so cookie is host-only on localhost)
@@ -24,5 +23,5 @@ spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
 # Set environment variables or in local.properties
 google.calendar.client-id=${GOOGLE_CLIENT_ID:}
 google.calendar.client-secret=${GOOGLE_CLIENT_SECRET:}
-google.calendar.redirect-uri=${GOOGLE_REDIRECT_URI:http://localhost:8080/api/calendar/callback}
+google.calendar.redirect-uri=${GOOGLE_REDIRECT_URI:http://localhost:8080/calendar/callback}
 google.calendar.frontend-redirect-uri=${FRONTEND_REDIRECT_URI:http://localhost:3000}


### PR DESCRIPTION
This PR fixes an issue with inconsistent basePath urls /api https://github.com/joshuademarco/sopra-fs26-group-08-client/issues/100
The issue occurred (rather suddenly) on production with the following errors:

```sh
layout-aaa9b7ab46f46279.js:1 WebSocket connection to 'wss://api.bettertogeter.ch/ws/raid' failed: 
a @ layout-aaa9b7ab46f46279.js:1
layout-aaa9b7ab46f46279.js:1 WebSocket connection to 'wss://api.bettertogeter.ch/ws/presence' failed: 
a @ layout-aaa9b7ab46f46279.js:1
layout-aaa9b7ab46f46279.js:1 WebSocket connection to 'wss://api.bettertogeter.ch/ws/character' failed: 
a @ layout-aaa9b7ab46f46279.js:1
layout-aaa9b7ab46f46279.js:1 WebSocket connection to 'wss://api.bettertogeter.ch/ws/raid' failed: 
a @ layout-aaa9b7ab46f46279.js:1
layout-aaa9b7ab46f46279.js:1 WebSocket connection to 'wss://api.bettertogeter.ch/ws/presence' failed: 
a @ layout-aaa9b7ab46f46279.js:1
layout-aaa9b7ab46f46279.js:1 WebSocket connection to 'wss://api.bettertogeter.ch/ws/character' failed:
which clearly shows no basePath being applied. However, the basePath was set in the fetch.
```

ref https://github.com/joshuademarco/sopra-fs26-group-08-server/issues/100

closes #130