### PR TITLE
feat: implemented missed habit health penalty and bugfix weather multiplier backend part. closes#9 #59 #60

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/HabitController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/HabitController.java
@@ -1,6 +1,6 @@
 package ch.uzh.ifi.hase.soprafs26.controller;
 
-import java.util.stream.Collectors;
+import java.util.ArrayList;
 import java.util.List;
 
 import org.springframework.http.HttpStatus;
@@ -42,11 +42,16 @@ public class HabitController {
         User requestingUser = userService.getUserByToken(token);
         verifyOwnership(requestingUser.getId(), userId);
 
-        List<Habit> habits = habitService.getHabitsForUser(userId);
+        int weatherCode = habitService.getWeatherCodeSafely();
 
-        return habits.stream()
-                .map(DTOMapper.INSTANCE::convertEntityToHabitGetDTO)
-                .collect(Collectors.toList());
+        List<Habit> habits = habitService.getHabitsForUser(userId);
+        List<HabitGetDTO> result = new ArrayList<>();
+        for (Habit habit : habits) {
+            HabitGetDTO dto = DTOMapper.INSTANCE.convertEntityToHabitGetDTO(habit);
+            dto.setMultiplier(habitService.getMultiplierForCategory(weatherCode, habit.getCategory()));
+            result.add(dto);
+        }
+        return result;
     }
 
     @PostMapping("/users/{userId}/habits")

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/Habit.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/Habit.java
@@ -32,9 +32,14 @@ public class Habit extends Task {
     @Column(nullable = false)
     private Integer streak = 0;
 
+    @Column
     private Instant dueAt;
 
+    @Column
     private Instant lastCompletedAt;
+
+    @Column(nullable = false)
+    private Boolean penaltyApplied = false;
 
     // getters and setters
     public User getUser() {
@@ -83,5 +88,13 @@ public class Habit extends Task {
 
     public void setLastCompletedAt(Instant lastCompletedAt) {
         this.lastCompletedAt = lastCompletedAt;
+    }
+
+    public Boolean getPenaltyApplied() {
+        return penaltyApplied;
+    }
+
+    public void setPenaltyApplied(Boolean penaltyApplied) {
+        this.penaltyApplied = penaltyApplied;
     }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/HabitGetDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/HabitGetDTO.java
@@ -12,12 +12,14 @@ public class HabitGetDTO {
     private HabitCategory category;
     private HabitFrequency frequency;
     private Boolean positive;
+    private Integer weight;
     private Boolean completed;
     private Integer streak;
     private Instant dueAt;
     private Instant createdAt;
     private Instant completedAt;
-    private Integer weight;
+    private Boolean penaltyApplied;
+    private Double multiplier;
 
     //getters and setters
     public Long getId() {
@@ -68,6 +70,14 @@ public class HabitGetDTO {
         this.positive = positive;
     }
 
+    public Integer getWeight() {
+        return weight;
+    }
+
+    public void setWeight(Integer weight) {
+        this.weight = weight;
+    }
+
     public Boolean getCompleted() {
         return completed;
     }
@@ -108,11 +118,19 @@ public class HabitGetDTO {
         this.completedAt = completedAt;
     }
 
-    public Integer getWeight() {
-        return weight;
+    public Boolean getPenaltyApplied() {
+        return penaltyApplied;
     }
 
-    public void setWeight(Integer weight) {
-        this.weight = weight;
+    public void setPenaltyApplied(Boolean penaltyApplied) {
+        this.penaltyApplied = penaltyApplied;
+    }
+
+    public Double getMultiplier() {
+        return multiplier;
+    }
+
+    public void setMultiplier(Double multiplier) {
+        this.multiplier = multiplier;
     }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/mapper/DTOMapper.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/mapper/DTOMapper.java
@@ -91,6 +91,7 @@ public interface DTOMapper {
     @Mapping(source = "dueAt", target = "dueAt")
     @Mapping(source = "createdAt", target = "createdAt")
     @Mapping(source = "completedAt", target = "completedAt")
+    @Mapping(source = "penaltyApplied", target = "penaltyApplied")
     HabitGetDTO convertEntityToHabitGetDTO(Habit habit);
 
     @Mapping(source = "title", target = "title")

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/HabitService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/HabitService.java
@@ -132,12 +132,15 @@ public class HabitService {
         List<Habit> overdueHabits = habitRepository.findByCompletedFalseAndDueAtBefore(now);
 
         for (Habit habit : overdueHabits) {
-            // habit not completed before due date -> break streak
+            if (habit.getPositive()) {
+                // positive habit missed then health penalty 
+                characterService.applyNegativeHabitPenalty(habit.getUser().getId(), habit.getWeight());
+                habit.setPenaltyApplied(true); // UI signal: show warning on this habit card (#60 + #7)
+            }
             habit.setStreak(0);
-            // push due date forward by one period so it becomes active again
-            habit.setDueAt(calculateDueDate(habit));
+            habit.setDueAt(calculateDueDate(habit)); 
             habitRepository.save(habit);
-            log.debug("Streak reset for overdue habit '{}'", habit.getTitle());
+            log.debug("Streak reset for overdue habit '{}', penalty={}", habit.getTitle(), habit.getPenaltyApplied());
         }
 
         // reset the completed flag for habits that are past due but were completed
@@ -145,7 +148,7 @@ public class HabitService {
         for (Habit habit : completedPastDue) {
             habit.setCompleted(false);
             habit.setCompletedAt(null);
-            habit.setDueAt(calculateDueDate(habit));
+            habit.setPenaltyApplied(false); 
             habitRepository.save(habit);
             log.debug("Reset completed habit '{}' for new period", habit.getTitle());
         }
@@ -158,6 +161,7 @@ public class HabitService {
             throw new ResponseStatusException(HttpStatus.FORBIDDEN,
                     "You can only delete your own habits");
         }
+        completionEventRepository.deleteAll(completionEventRepository.findByHabitId(habitId));
         habitRepository.delete(habit);
     }
 
@@ -189,13 +193,17 @@ public class HabitService {
         }
     }
 
-    private int getWeatherCodeSafely() {
+    public int getWeatherCodeSafely() {
         try {
             String json = weatherService.getWeather();
             return weatherService.parseWeatherData(json);
         } catch (Exception e) {
             return 0; // safety default (0 = clear sky) if API broken
         }
+    }
+
+    public double getMultiplierForCategory(int weatherCode, HabitCategory category) {
+        return weatherService.getMultiplier(weatherCode, category.name().toLowerCase());
     }
 
     private Instant calculateDueDate(Habit habit) {

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/HabitServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/HabitServiceTest.java
@@ -14,6 +14,8 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Optional;
 
@@ -226,6 +228,88 @@ public class HabitServiceTest {
         when(habitRepository.findById(99L)).thenReturn(Optional.empty());
 
         assertThrows(ResponseStatusException.class, () -> habitService.deleteHabit(99L, 1L));
+    }
+
+    // ---------------tests for resetOverdueHabits ---------------
+    @Test
+    public void resetOverdueHabits_positiveHabitMissed_appliesHealthPenalty() {
+        testHabit.setPositive(true);
+        testHabit.setDueAt(Instant.now().minus(1, ChronoUnit.HOURS));
+        testHabit.setCompleted(false);
+        testHabit.setPenaltyApplied(false);
+
+        when(habitRepository.findByCompletedFalseAndDueAtBefore(any())).thenReturn(List.of(testHabit));
+        when(habitRepository.findByCompletedTrueAndDueAtBefore(any())).thenReturn(List.of());
+
+        habitService.resetOverdueHabits();
+
+        // health penalty must be applied for missed positive habit
+        verify(characterService, times(1)).applyNegativeHabitPenalty(eq(1L), eq(1));
+        assertTrue(testHabit.getPenaltyApplied());
+    }
+
+    @Test
+    public void resetOverdueHabits_negativeHabitMissed_noPenalty() {
+        // missing a negative habit should NOT give penalty
+        testHabit.setPositive(false);
+        testHabit.setDueAt(Instant.now().minus(1, ChronoUnit.HOURS));
+        testHabit.setCompleted(false);
+
+        when(habitRepository.findByCompletedFalseAndDueAtBefore(any())).thenReturn(List.of(testHabit));
+        when(habitRepository.findByCompletedTrueAndDueAtBefore(any())).thenReturn(List.of());
+
+        habitService.resetOverdueHabits();
+
+        verify(characterService, never()).applyNegativeHabitPenalty(any(), any());
+        assertFalse(testHabit.getPenaltyApplied());
+    }
+
+    @Test
+    public void resetOverdueHabits_missedHabit_resetsStreak() {
+        testHabit.setStreak(5);
+        testHabit.setDueAt(Instant.now().minus(1, ChronoUnit.HOURS));
+        testHabit.setCompleted(false);
+
+        when(habitRepository.findByCompletedFalseAndDueAtBefore(any())).thenReturn(List.of(testHabit));
+        when(habitRepository.findByCompletedTrueAndDueAtBefore(any())).thenReturn(List.of());
+
+        habitService.resetOverdueHabits();
+
+        assertEquals(0, testHabit.getStreak());
+    }
+
+    @Test
+    public void resetOverdueHabits_completedHabitReset_clearsPenaltyApplied() {
+        testHabit.setCompleted(true);
+        testHabit.setPenaltyApplied(true);
+        testHabit.setDueAt(Instant.now().minus(1, ChronoUnit.HOURS));
+
+        when(habitRepository.findByCompletedFalseAndDueAtBefore(any())).thenReturn(List.of());
+        when(habitRepository.findByCompletedTrueAndDueAtBefore(any())).thenReturn(List.of(testHabit));
+
+        habitService.resetOverdueHabits();
+
+        assertFalse(testHabit.getPenaltyApplied());
+        assertFalse(testHabit.getCompleted());
+        assertNull(testHabit.getCompletedAt());
+    }
+
+    @Test
+    public void resetOverdueHabits_calledTwice_penaltyAppliedOnlyOnce() {
+        testHabit.setPositive(true);
+        testHabit.setDueAt(Instant.now().minus(1, ChronoUnit.HOURS));
+        testHabit.setCompleted(false);
+
+        when(habitRepository.findByCompletedFalseAndDueAtBefore(any()))
+                .thenReturn(List.of(testHabit)) // first run -> habit is overdue
+                .thenReturn(List.of()); // second run -> dueAt pushed to future, hence not found
+        when(habitRepository.findByCompletedTrueAndDueAtBefore(any())).thenReturn(List.of());
+
+        habitService.resetOverdueHabits();
+        habitService.resetOverdueHabits();
+
+        // penalty applied exactly once despite two scheduler executions
+        verify(characterService, times(1)).applyNegativeHabitPenalty(eq(1L), eq(1));
     }
 
     @Test


### PR DESCRIPTION
implemented backend penalty system with adjustments in habit entity, service, controller, DTO and added tests.
- not completing habits before the due date will now result in health penalty. so according to the difficulty of the habit the corresponding amount of HP will be deducted (missing completion of a "medium" habit will result in -2 HP for the character" -> closes #59 
- penalty is only applied once due to the 'penatlyApplied' flag that is persisted in DB and serves as UI signal for frontend. flag resets to false once the user completes a habit period -> closes #60 
- partial bug fix of weather multiplier, now logic lives in backend. meaning the GET /users/{userId}/habits response now includes 'multiplier' - so backend only source of truth.