### PR TITLE
Improved flow for boss raids

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/RaidController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/RaidController.java
@@ -1,5 +1,6 @@
 package ch.uzh.ifi.hase.soprafs26.controller;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -50,6 +51,13 @@ public class RaidController {
         raidService.joinRaid(raidId, token);
     }
 
+    @PostMapping("/raids/{raidId}/rsvp")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void rsvpRaid(@PathVariable Long raidId, @RequestParam boolean accepted,
+            @CookieValue(name = "token", required = true) String token) {
+        raidService.rsvpRaid(raidId, accepted, token);
+    }
+
     @PostMapping("/raids/{raidId}/tasks/{taskId}/complete")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void completeTask(@PathVariable Long raidId, @PathVariable Long taskId, @RequestParam Boolean success,
@@ -69,5 +77,45 @@ public class RaidController {
             @RequestParam(defaultValue = "7") int windowDays) {
         BossRaid raid = raidService.rescheduleRaid(raidId, windowDays);
         return DTOMapper.INSTANCE.convertEntityToRaidGetDTO(raid);
+    }
+
+    // TODO: Remove this admin endpoint again
+
+    @PostMapping("/admin/groups/{groupId}/schedule")
+    @ResponseStatus(HttpStatus.CREATED)
+    public void adminScheduleGroup(@PathVariable Long groupId, @RequestParam(required = false) String earliest) {
+        if (earliest != null && !earliest.isEmpty()) {
+            Instant earliestTime = Instant.parse(earliest);
+            raidService.adminScheduleForGroupWithEarliest(groupId, earliestTime);
+        } else {
+            raidService.adminAutoScheduleForGroup(groupId);
+        }
+    }
+
+    @PostMapping("/admin/groups/{groupId}/start-raid")
+    @ResponseStatus(HttpStatus.CREATED)
+    public RaidGetDTO adminStartRaidImmediately(@PathVariable Long groupId) {
+        BossRaid raid = raidService.adminStartRaidImmediately(groupId);
+        return raidService.convertEntityToRaidGetDTO(raid);
+    }
+
+    @PostMapping("/admin/raids/{raidId}/fast-forward")
+    public RaidGetDTO adminFastForward(@PathVariable Long raidId,
+            @RequestParam(defaultValue = "10") int seconds) {
+        BossRaid raid = raidService.adminFastForwardRaid(raidId, seconds);
+        return raidService.convertEntityToRaidGetDTO(raid);
+    }
+
+    @PostMapping("/admin/raids/{raidId}/force-complete")
+    public RaidGetDTO adminForceComplete(@PathVariable Long raidId,
+            @RequestParam(defaultValue = "DEFEATED") String outcome) {
+        BossRaid raid = raidService.adminForceCompleteRaid(raidId, outcome);
+        return raidService.convertEntityToRaidGetDTO(raid);
+    }
+
+    @DeleteMapping("/admin/groups/{groupId}/raids")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void adminClearRaids(@PathVariable Long groupId) {
+        raidService.adminClearGroupRaids(groupId);
     }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/RaidParticipation.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/RaidParticipation.java
@@ -31,6 +31,14 @@ public class RaidParticipation {
     @Column(nullable = false)
     private Integer tasksFailed = 0;
 
+    @Column(nullable = false)
+    private Integer xpEarned = 0;
+
+    @Column(nullable = false)
+    private Boolean mvp = false;
+
+    private Boolean accepted;
+
     @PrePersist
     protected void onCreate() {
         this.joinedAt = Instant.now();
@@ -90,5 +98,29 @@ public class RaidParticipation {
 
     public void setTasksFailed(Integer tasksFailed) {
         this.tasksFailed = tasksFailed;
+    }
+
+    public Boolean getAccepted() {
+        return accepted;
+    }
+
+    public void setAccepted(Boolean accepted) {
+        this.accepted = accepted;
+    }
+
+    public Integer getXpEarned() {
+        return xpEarned;
+    }
+
+    public void setXpEarned(Integer xpEarned) {
+        this.xpEarned = xpEarned;
+    }
+
+    public Boolean getMvp() {
+        return mvp;
+    }
+
+    public void setMvp(Boolean mvp) {
+        this.mvp = mvp;
     }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/RaidTaskCompletion.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/RaidTaskCompletion.java
@@ -25,6 +25,10 @@ public class RaidTaskCompletion {
 
     private Instant completedAt;
 
+    protected void onCreate() {
+        this.completedAt = Instant.now();
+    }
+
     public RaidParticipation getParticipation() {
         return participation;
     }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/BossRaidRepository.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/BossRaidRepository.java
@@ -3,7 +3,9 @@ package ch.uzh.ifi.hase.soprafs26.repository;
 import org.springframework.stereotype.Repository;
 
 import java.time.Instant;
+import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -15,4 +17,6 @@ public interface BossRaidRepository extends JpaRepository<BossRaid, Long> {
     List<BossRaid> findByGroupId(Long groupId);
     List<BossRaid> findByStatus(RaidStatus status);
     List<BossRaid> findByStatusAndScheduledTimeBefore(RaidStatus status, Instant time);
+    List<BossRaid> findByGroupIdAndStatusAndScheduledTimeAfter(Long groupId, RaidStatus status, Instant time);
+    Optional<BossRaid> findTopByGroupIdAndStatusInOrderByEndedAtDesc(Long groupId, Collection<RaidStatus> statuses);
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/RaidParticipationRepository.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/repository/RaidParticipationRepository.java
@@ -19,4 +19,5 @@ public interface RaidParticipationRepository extends JpaRepository<RaidParticipa
     List<RaidParticipation> findByBossRaidId(Long id);
 
     Optional<RaidParticipation> findByBossRaidAndUser(BossRaid bossRaid, User user);
+    long countByBossRaidIdAndAccepted(Long bossRaidId, Boolean accepted);
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/RaidGetDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/RaidGetDTO.java
@@ -114,4 +114,5 @@ public class RaidGetDTO {
     public void setTasks(List<RaidTaskDTO> tasks) {
         this.tasks = tasks;
     }
+
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/RaidMemberDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/RaidMemberDTO.java
@@ -7,12 +7,15 @@ public class RaidMemberDTO {
     private String username;
     private UserStatus online;
     private Boolean joined;
+    private Boolean accepted;
     private Integer tasksCompleted;
     private Integer tasksFailed;
     private Integer damageDealt;
     private Integer health;
     private Integer maxHealth;
     private String characterType;
+    private Integer xpEarned;
+    private Boolean mvp;
 
     public Long getUserId() {
         return userId;
@@ -44,6 +47,14 @@ public class RaidMemberDTO {
 
     public void setJoined(Boolean joined) {
         this.joined = joined;
+    }
+
+    public Boolean getAccepted() {
+        return accepted;
+    }
+
+    public void setAccepted(Boolean accepted) {
+        this.accepted = accepted;
     }
 
     public Integer getTasksCompleted() {
@@ -92,5 +103,21 @@ public class RaidMemberDTO {
 
     public void setCharacterType(String characterType) {
         this.characterType = characterType;
+    }
+
+    public Integer getXpEarned() {
+        return xpEarned;
+    }
+
+    public void setXpEarned(Integer xpEarned) {
+        this.xpEarned = xpEarned;
+    }
+
+    public Boolean getMvp() {
+        return mvp;
+    }
+
+    public void setMvp(Boolean mvp) {
+        this.mvp = mvp;
     }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/CalendarService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/CalendarService.java
@@ -33,7 +33,7 @@ public class CalendarService {
     private static final String GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token";
     private static final String GOOGLE_CALENDAR_EVENTS_URL = "https://www.googleapis.com/calendar/v3/calendars/primary/events";
     private static final String GOOGLE_FREEBUSY_URL = "https://www.googleapis.com/calendar/v3/freeBusy";
-    private static final String GOOGLE_CALENDAR_SCOPE = "https://www.googleapis.com/auth/calendar.readonly";
+    private static final String GOOGLE_CALENDAR_SCOPE = "https://www.googleapis.com/auth/calendar.events";
 
     // Fixed issue of not mapping correct values
     // source:
@@ -102,6 +102,43 @@ public class CalendarService {
     /** Removes stored Google Calendar tokens for the user. */
     public void disconnect(Long userId) {
         calendarTokenRepository.findByUserId(userId).ifPresent(calendarTokenRepository::delete);
+    }
+
+    /** Adds a raid event to the user Google Calendar. TEST if this really works */
+    public void addRaidEventToCalendar(Long userId, String raidName, Instant start, Instant end) {
+        if (!isConnected(userId))
+            return;
+        CalendarToken token;
+        try {
+            token = getValidToken(userId);
+        } catch (Exception e) {
+            return;
+        }
+
+        JSONObject startObj = new JSONObject();
+        startObj.put("dateTime", start.toString());
+        startObj.put("timeZone", "UTC");
+
+        JSONObject endObj = new JSONObject();
+        endObj.put("dateTime", end.toString());
+        endObj.put("timeZone", "UTC");
+
+        JSONObject event = new JSONObject();
+        event.put("summary", "Boss Raid: " + raidName);
+        event.put("start", startObj);
+        event.put("end", endObj);
+
+        try {
+            HttpClient client = HttpClient.newHttpClient();
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(GOOGLE_CALENDAR_EVENTS_URL))
+                    .header("Authorization", "Bearer " + token.getAccessToken())
+                    .header("Content-Type", "application/json")
+                    .POST(HttpRequest.BodyPublishers.ofString(event.toString()))
+                    .build();
+            client.send(request, HttpResponse.BodyHandlers.ofString());
+        } catch (Exception e) {
+        }
     }
 
     public List<CalendarEventGetDTO> getEvents(Long userId) {

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/RaidScheduler.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/RaidScheduler.java
@@ -26,4 +26,9 @@ public class RaidScheduler {
     public void expireOverdueTasks() {
         raidService.expireOverdueTasks();
     }
+
+    @Scheduled(fixedDelay = 6 * 60 * 60 * 1000) // every 6 hours
+    public void autoScheduleRaids() {
+        raidService.autoScheduleRaidsForAllGroups();
+    }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/RaidService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/RaidService.java
@@ -84,7 +84,9 @@ public class RaidService {
         raid = bossRaidRepository.save(raid);
 
         int windowDays = dto.getSearchWindowDays() != null ? dto.getSearchWindowDays() : 7;
-        tryAutoSchedule(raid, group, windowDays);
+        if (tryAutoSchedule(raid, group, windowDays)) {
+            createCalendarEventsForRaid(raid);
+        }
 
         return raid;
     }
@@ -97,7 +99,9 @@ public class RaidService {
             throw new ResponseStatusException(HttpStatus.CONFLICT, "Only SCHEDULED raids can be rescheduled");
         }
 
-        tryAutoSchedule(raid, raid.getGroup(), windowDays);
+        if (tryAutoSchedule(raid, raid.getGroup(), windowDays)) {
+            createCalendarEventsForRaid(raid);
+        }
         return raid;
     }
 
@@ -130,9 +134,7 @@ public class RaidService {
             Map<Long, RaidParticipation> participationByUserId = participations.stream()
                     .collect(Collectors.toMap(p -> p.getUser().getId(), p -> p));
 
-            List<User> raidMembers = raid.getStatus() == RaidStatus.ACTIVE
-                    ? getAliveGroupUsers(group)
-                    : new ArrayList<>(group.getUsers());
+            List<User> raidMembers = new ArrayList<>(group.getUsers());
             List<RaidMemberDTO> members = new ArrayList<>();
             for (User user : raidMembers) {
                 RaidMemberDTO member = new RaidMemberDTO();
@@ -141,10 +143,13 @@ public class RaidService {
                 member.setOnline(user.getStatus());
 
                 RaidParticipation p = participationByUserId.get(user.getId());
-                member.setJoined(p != null);
+                member.setJoined(p != null && p.getAccepted());
+                member.setAccepted(p != null ? p.getAccepted() : null);
                 member.setTasksCompleted(p != null ? p.getTasksCompleted() : 0);
                 member.setTasksFailed(p != null ? p.getTasksFailed() : 0);
                 member.setDamageDealt(p != null ? p.getDamageDealt() : 0);
+                member.setXpEarned(p != null ? p.getXpEarned() : 0);
+                member.setMvp(p != null && Boolean.TRUE.equals(p.getMvp()));
 
                 Character character = user.getCharacter();
                 member.setHealth(character.getHealth());
@@ -167,6 +172,52 @@ public class RaidService {
         dto.setTasks(taskDTOs);
 
         return dto;
+    }
+
+    private void endRaidWithRewards(BossRaid raid, RaidStatus outcome) {
+        raid.endRaid(outcome);
+        List<RaidParticipation> participations = raidParticipationRepository.findByBossRaidId(raid.getId());
+        if (participations.isEmpty())
+            return;
+
+        RaidParticipation top = null;
+        for (RaidParticipation p : participations) {
+            int xp;
+            if (outcome == RaidStatus.DEFEATED) {
+                xp = (p.getDamageDealt() != null ? p.getDamageDealt() : 0)
+                        + (p.getTasksCompleted() != null ? p.getTasksCompleted() : 0) * 10;
+            } else {
+                xp = (p.getTasksCompleted() != null ? p.getTasksCompleted() : 0) * 5;
+            }
+            p.setXpEarned(xp);
+            p.setMvp(false);
+            if (top == null
+                    || (p.getDamageDealt() != null ? p.getDamageDealt()
+                            : 0) > (top.getDamageDealt() != null ? top.getDamageDealt() : 0)) {
+                top = p;
+            }
+        }
+        if (outcome == RaidStatus.DEFEATED && top != null
+                && (top.getDamageDealt() != null ? top.getDamageDealt() : 0) > 0) {
+            top.setMvp(true);
+            top.setXpEarned(top.getXpEarned() + 50);
+        }
+
+        for (RaidParticipation p : participations) {
+            int xp = p.getXpEarned();
+            if (xp > 0) {
+                Character character = p.getUser().getCharacter();
+                if (character != null) {
+                    character.addExperience(xp);
+                    try {
+                        characterLiveService.broadcastCharacterUpdate(p.getUser().getId(), character);
+                    } catch (Exception ignored) {
+                    }
+                }
+            }
+            raidParticipationRepository.save(p);
+        }
+        userRepository.saveAll(participations.stream().map(RaidParticipation::getUser).collect(Collectors.toList()));
     }
 
     private RaidTaskDTO buildRaidTaskDTO(RaidTask task, Map<Long, Integer> userWindowOffset) {
@@ -208,6 +259,12 @@ public class RaidService {
     public void activateDueRaids() {
         List<BossRaid> due = bossRaidRepository.findByStatusAndScheduledTimeBefore(RaidStatus.SCHEDULED, Instant.now());
         for (BossRaid raid : due) {
+            long confirmed = raidParticipationRepository.countByBossRaidIdAndAccepted(raid.getId(), true);
+            if (confirmed < 2) {
+                deleteRaid(raid);
+                broadcastRaidDeletion(raid);
+                continue;
+            }
             raid.startRaid();
             bossRaidRepository.save(raid);
             broadcastRaidUpdate(raid);
@@ -228,7 +285,7 @@ public class RaidService {
             }
             Instant deadline = raid.getStartedAt().plusSeconds(raid.getDurationSeconds());
             if (now.isAfter(deadline)) {
-                raid.endRaid(RaidStatus.FAILED);
+                endRaidWithRewards(raid, RaidStatus.FAILED);
                 bossRaidRepository.save(raid);
                 broadcastRaidUpdate(raid);
             }
@@ -246,14 +303,44 @@ public class RaidService {
                     "Your character is knocked out and cannot join the raid!");
         }
 
-        raidParticipationRepository.findByBossRaidAndUser(raid, user).ifPresent(p -> {
-            throw new ResponseStatusException(HttpStatus.CONFLICT, "Already joined this raid");
-        });
+        java.util.Optional<RaidParticipation> existing = raidParticipationRepository.findByBossRaidAndUser(raid, user);
+        if (existing.isPresent()) {
+            RaidParticipation p = existing.get();
+            if (Boolean.TRUE.equals(p.getAccepted())) {
+                throw new ResponseStatusException(HttpStatus.CONFLICT, "Already joined this raid");
+            }
+            // Previously declined or no response — allow joining an active raid
+            p.setAccepted(true);
+            return raidParticipationRepository.save(p);
+        }
 
         RaidParticipation participation = new RaidParticipation();
         participation.setUser(user);
         participation.setBossRaid(raid);
+        participation.setAccepted(true);
         return raidParticipationRepository.save(participation);
+    }
+
+    public void rsvpRaid(Long raidId, boolean accepted, String token) {
+        BossRaid raid = bossRaidRepository.findById(raidId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Raid not found"));
+
+        if (raid.getStatus() != RaidStatus.SCHEDULED) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "RSVP is only available for scheduled raids");
+        }
+
+        User user = resolveUser(token);
+
+        RaidParticipation participation = raidParticipationRepository.findByBossRaidAndUser(raid, user)
+                .orElseGet(() -> {
+                    RaidParticipation p = new RaidParticipation();
+                    p.setUser(user);
+                    p.setBossRaid(raid);
+                    return p;
+                });
+
+        participation.setAccepted(accepted);
+        raidParticipationRepository.save(participation);
     }
 
     // Keep session open due to LAZY relations
@@ -302,8 +389,13 @@ public class RaidService {
         }
         raidParticipationRepository.save(participation);
 
-        if (raid.getStatus() == RaidStatus.ACTIVE && allParticipantsKnockedOut(raid)) {
-            raid.endRaid(RaidStatus.FAILED);
+        // applyDamage may have already set DEFEATED above; reward in that case too
+        if (raid.getStatus() == RaidStatus.DEFEATED || raid.getStatus() == RaidStatus.FAILED) {
+            endRaidWithRewards(raid, raid.getStatus());
+        } else if (allParticipantsKnockedOut(raid)) {
+            endRaidWithRewards(raid, RaidStatus.FAILED);
+        } else if (allTasksCompleted(raid)) {
+            endRaidWithRewards(raid, RaidStatus.DEFEATED);
         }
         bossRaidRepository.save(raid);
 
@@ -368,7 +460,10 @@ public class RaidService {
                 }
 
                 if (raid.getStatus() == RaidStatus.ACTIVE && allParticipantsKnockedOut(raid)) {
-                    raid.endRaid(RaidStatus.FAILED);
+                    endRaidWithRewards(raid, RaidStatus.FAILED);
+                    bossRaidRepository.save(raid);
+                } else if (raid.getStatus() == RaidStatus.ACTIVE && allTasksCompleted(raid)) {
+                    endRaidWithRewards(raid, RaidStatus.DEFEATED);
                     bossRaidRepository.save(raid);
                 }
 
@@ -472,8 +567,11 @@ public class RaidService {
         raid.setGroup(group);
         raid.setName("Innere Schweinehund");
         raid.setDurationSeconds(300);
-        raid.setScheduledTime(Instant.now());
+        // 20-second join window — activateDueRaids fires the actual ACTIVE transition
+        raid.setScheduledTime(Instant.now().plusSeconds(20));
         raid.setStatus(RaidStatus.SCHEDULED);
+        raid.setHealth(1);
+        raid.setMaxHealth(1);
         raid = bossRaidRepository.save(raid);
 
         List<User> members = getAliveGroupUsers(group);
@@ -481,55 +579,28 @@ public class RaidService {
             int bossHealth = calculateBossHealth(raid, 0);
             raid.setHealth(bossHealth);
             raid.setMaxHealth(bossHealth);
-            raid.startRaid();
             bossRaidRepository.save(raid);
             broadcastRaidUpdate(raid);
             return raid;
         }
 
-        int size = members.size();
+        createQuickTasksForRaid(raid, members);
 
-        createQuickTask(raid, members.get(0 % size), "Make your bed", "Tidy your bed right now", HabitCategory.PHYSICAL,
-                80, 1, 1, 60);
-        createQuickTask(raid, members.get(1 % size), "Stretch your legs", "Stretch both of your legs now!",
-                HabitCategory.PHYSICAL, 80, 1, 1, 60);
-        createQuickTask(raid, members.get(2 % size), "Deep breathing", "Take 10 slow deep breaths",
-                HabitCategory.EMOTIONAL, 80, 1, 1, 60);
-        createQuickTask(raid, members.get(3 % size), "Drink a glass of water", "Finish one full glass",
-                HabitCategory.PHYSICAL, 80, 1, 1, 60);
-
-        createQuickTask(raid, members.get(0 % size), "Desk cleanup", "Remove clutter from your desk",
-                HabitCategory.COGNITIVE, 90, 2, 2, 60);
-        createQuickTask(raid, members.get(1 % size), "Do 10 Push-ups", "Perform 10 push-ups", HabitCategory.PHYSICAL,
-                90, 2, 2, 60);
-        createQuickTask(raid, members.get(2 % size), "Posture check", "Make sure you sit and stand straight",
-                HabitCategory.PHYSICAL, 90, 2, 2, 15);
-        createQuickTask(raid, members.get(3 % size), "Positivity Check", "Write down 3 things positive about yourself",
-                HabitCategory.EMOTIONAL, 90, 2, 2, 60);
-
-        createQuickTask(raid, members.get(0 % size), "Gratefulness Check", "Write down 3 things you're grateful for",
-                HabitCategory.COGNITIVE, 100, 4, 3, 45);
-        createQuickTask(raid, members.get(1 % size), "Answer unread messages", "Reply to 3 unread messages",
-                HabitCategory.COGNITIVE, 100, 4, 3, 60);
-        createQuickTask(raid, members.get(2 % size), "Refill water bottle", "Refill and place it on your desk",
-                HabitCategory.PHYSICAL, 100, 4, 3, 30);
-        createQuickTask(raid, members.get(3 % size), "One positive message", "Send an encouraging message to someone",
-                HabitCategory.EMOTIONAL, 100, 4, 3, 60);
-
-        createQuickTask(raid, members.get(0 % size), "Plan top 3 tasks", "List your top 3 priorities for today",
-                HabitCategory.COGNITIVE, 110, 5, 4, 60);
-        createQuickTask(raid, members.get(1 % size), "Eye break", "Look away from the screen for 60 seconds",
-                HabitCategory.EMOTIONAL, 110, 5, 4, 60);
-        createQuickTask(raid, members.get(2 % size), "10 squats", "Do 10 bodyweight squats", HabitCategory.PHYSICAL,
-                110, 5, 4, 60);
-        createQuickTask(raid, members.get(3 % size), "Clear one small task", "Complete one pending micro-task",
-                HabitCategory.COGNITIVE, 110, 5, 4, 60);
-
-        int bossHealth = calculateBossHealth(raid, size);
+        int bossHealth = calculateBossHealth(raid, members.size());
         raid.setHealth(bossHealth);
         raid.setMaxHealth(bossHealth);
 
-        raid.startRaid();
+        // Pre-accept all alive members; they may decline within the 20-second window
+        for (User member : members) {
+            RaidParticipation participation = new RaidParticipation();
+            participation.setUser(member);
+            participation.setBossRaid(raid);
+            participation.setAccepted(true);
+            raidParticipationRepository.save(participation);
+        }
+        // Also invite the rest of the group as pending
+        inviteAllGroupMembers(raid, group);
+
         bossRaidRepository.save(raid);
         broadcastRaidUpdate(raid);
 
@@ -551,13 +622,74 @@ public class RaidService {
         raidTaskRepository.save(task);
     }
 
-    private void tryAutoSchedule(BossRaid raid, Group group, int windowDays) {
+    private void createQuickTasksForRaid(BossRaid raid, List<User> members) {
+        if (members.isEmpty())
+            return;
+        int size = members.size();
+        createQuickTask(raid, members.get(0 % size), "Make your bed", "Tidy your bed right now", HabitCategory.PHYSICAL,
+                80, 1, 1, 60);
+        createQuickTask(raid, members.get(1 % size), "Stretch your legs", "Stretch both of your legs now!",
+                HabitCategory.PHYSICAL, 80, 1, 1, 60);
+        createQuickTask(raid, members.get(2 % size), "Deep breathing", "Take 10 slow deep breaths",
+                HabitCategory.EMOTIONAL, 80, 1, 1, 60);
+        createQuickTask(raid, members.get(3 % size), "Drink a glass of water", "Finish one full glass",
+                HabitCategory.PHYSICAL, 80, 1, 1, 60);
+        createQuickTask(raid, members.get(0 % size), "Desk cleanup", "Remove clutter from your desk",
+                HabitCategory.COGNITIVE, 90, 2, 2, 60);
+        createQuickTask(raid, members.get(1 % size), "Do 10 Push-ups", "Perform 10 push-ups", HabitCategory.PHYSICAL,
+                90, 2, 2, 60);
+        createQuickTask(raid, members.get(2 % size), "Posture check", "Make sure you sit and stand straight",
+                HabitCategory.PHYSICAL, 90, 2, 2, 15);
+        createQuickTask(raid, members.get(3 % size), "Positivity Check", "Write down 3 things positive about yourself",
+                HabitCategory.EMOTIONAL, 90, 2, 2, 60);
+        createQuickTask(raid, members.get(0 % size), "Gratefulness Check", "Write down 3 things you're grateful for",
+                HabitCategory.COGNITIVE, 100, 4, 3, 45);
+        createQuickTask(raid, members.get(1 % size), "Answer unread messages", "Reply to 3 unread messages",
+                HabitCategory.COGNITIVE, 100, 4, 3, 60);
+        createQuickTask(raid, members.get(2 % size), "Refill water bottle", "Refill and place it on your desk",
+                HabitCategory.PHYSICAL, 100, 4, 3, 30);
+        createQuickTask(raid, members.get(3 % size), "One positive message", "Send an encouraging message to someone",
+                HabitCategory.EMOTIONAL, 100, 4, 3, 60);
+        createQuickTask(raid, members.get(0 % size), "Plan top 3 tasks", "List your top 3 priorities for today",
+                HabitCategory.COGNITIVE, 110, 5, 4, 60);
+        createQuickTask(raid, members.get(1 % size), "Eye break", "Look away from the screen for 60 seconds",
+                HabitCategory.EMOTIONAL, 110, 5, 4, 60);
+        createQuickTask(raid, members.get(2 % size), "10 squats", "Do 10 bodyweight squats", HabitCategory.PHYSICAL,
+                110, 5, 4, 60);
+        createQuickTask(raid, members.get(3 % size), "Clear one small task", "Complete one pending micro-task",
+                HabitCategory.COGNITIVE, 110, 5, 4, 60);
+    }
+
+    private void inviteAllGroupMembers(BossRaid raid, Group group) {
+        for (User member : group.getUsers()) {
+            if (raidParticipationRepository.findByBossRaidAndUser(raid, member).isPresent())
+                continue;
+            RaidParticipation p = new RaidParticipation();
+            p.setUser(member);
+            p.setBossRaid(raid);
+            p.setAccepted(null);
+            raidParticipationRepository.save(p);
+        }
+    }
+
+    private boolean allTasksCompleted(BossRaid raid) {
+        List<RaidTask> tasks = raidTaskRepository.findByRaid(raid);
+        if (tasks.isEmpty())
+            return false;
+        for (RaidTask task : tasks) {
+            if (raidTaskCompletionRepository.findByRaidTask(task).isEmpty())
+                return false;
+        }
+        return true;
+    }
+
+    private boolean tryAutoSchedule(BossRaid raid, Group group, int windowDays) {
         List<Long> memberIds = group.getUsers().stream()
                 .map(u -> u.getId())
                 .collect(Collectors.toList());
 
         if (memberIds.isEmpty())
-            return;
+            return false;
 
         Instant from = Instant.now();
         Instant to = from.plus(windowDays, ChronoUnit.DAYS);
@@ -573,8 +705,210 @@ public class RaidService {
             if (slotSeconds >= requiredSeconds) {
                 raid.setScheduledTime(slotStart);
                 bossRaidRepository.save(raid);
-                return;
+                return true;
             }
         }
+        return false;
+    }
+
+    private void createCalendarEventsForRaid(BossRaid raid) {
+        if (raid.getScheduledTime() == null)
+            return;
+        Instant start = raid.getScheduledTime();
+        Instant end = start.plusSeconds(raid.getDurationSeconds());
+        for (User member : raid.getGroup().getUsers()) {
+            calendarService.addRaidEventToCalendar(member.getId(), raid.getName(), start, end);
+        }
+    }
+
+    @Transactional
+    public void autoScheduleRaidsForAllGroups() {
+        Instant now = Instant.now();
+        Instant threeDaysAgo = now.minus(3, ChronoUnit.DAYS);
+
+        List<Group> allGroups = groupRepository.findAll();
+
+        for (Group group : allGroups) {
+            if (!bossRaidRepository.findByGroupIdAndStatusAndScheduledTimeAfter(
+                    group.getId(), RaidStatus.SCHEDULED, now).isEmpty())
+                continue;
+
+            java.util.Optional<BossRaid> last = bossRaidRepository
+                    .findTopByGroupIdAndStatusInOrderByEndedAtDesc(
+                            group.getId(), List.of(RaidStatus.DEFEATED, RaidStatus.FAILED));
+            if (last.isPresent() && last.get().getEndedAt() != null
+                    && last.get().getEndedAt().isAfter(threeDaysAgo))
+                continue;
+
+            BossRaid newRaid = new BossRaid();
+            newRaid.setGroup(group);
+            newRaid.setName("Innere Schweinehund");
+            newRaid.setDurationSeconds(1800);
+            newRaid.setStatus(RaidStatus.SCHEDULED);
+            newRaid.setHealth(1);
+            newRaid.setMaxHealth(1);
+            newRaid = bossRaidRepository.save(newRaid);
+
+            List<User> members = getAliveGroupUsers(group);
+            createQuickTasksForRaid(newRaid, members);
+            int bossHealth = calculateBossHealth(newRaid, members.size());
+            newRaid.setHealth(bossHealth);
+            newRaid.setMaxHealth(bossHealth);
+            newRaid = bossRaidRepository.save(newRaid);
+
+            inviteAllGroupMembers(newRaid, group);
+
+            if (tryAutoSchedule(newRaid, group, 7)) {
+                createCalendarEventsForRaid(newRaid);
+            }
+        }
+    }
+
+    // ── Admin / testing helpers ──────────────────────────────────────────────
+
+    @Transactional
+    public void adminAutoScheduleForGroup(Long groupId) {
+        Group group = groupRepository.findById(groupId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Group not found"));
+
+        BossRaid newRaid = new BossRaid();
+        newRaid.setGroup(group);
+        newRaid.setName("Innere Schweinehund");
+        newRaid.setDurationSeconds(1800);
+        newRaid.setStatus(RaidStatus.SCHEDULED);
+        newRaid.setHealth(1);
+        newRaid.setMaxHealth(1);
+        newRaid = bossRaidRepository.save(newRaid);
+
+        List<User> members = getAliveGroupUsers(group);
+        createQuickTasksForRaid(newRaid, members);
+        int bossHealth = calculateBossHealth(newRaid, members.size());
+        newRaid.setHealth(bossHealth);
+        newRaid.setMaxHealth(bossHealth);
+        newRaid = bossRaidRepository.save(newRaid);
+
+        inviteAllGroupMembers(newRaid, group);
+
+        if (tryAutoSchedule(newRaid, group, 7)) {
+            createCalendarEventsForRaid(newRaid);
+        }
+    }
+
+    @Transactional
+    public void adminScheduleForGroupWithEarliest(Long groupId, Instant earliest) {
+        Group group = groupRepository.findById(groupId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Group not found"));
+
+        BossRaid newRaid = new BossRaid();
+        newRaid.setGroup(group);
+        newRaid.setName("Innere Schweinehund");
+        newRaid.setDurationSeconds(1800);
+        newRaid.setStatus(RaidStatus.SCHEDULED);
+        newRaid.setHealth(1);
+        newRaid.setMaxHealth(1);
+        newRaid = bossRaidRepository.save(newRaid);
+
+        List<User> members = getAliveGroupUsers(group);
+        createQuickTasksForRaid(newRaid, members);
+        int bossHealth = calculateBossHealth(newRaid, members.size());
+        newRaid.setHealth(bossHealth);
+        newRaid.setMaxHealth(bossHealth);
+        newRaid = bossRaidRepository.save(newRaid);
+
+        inviteAllGroupMembers(newRaid, group);
+
+        // Schedule to the earliest time (5 minutes from now)
+        newRaid.setScheduledTime(earliest);
+        bossRaidRepository.save(newRaid);
+        createCalendarEventsForRaid(newRaid);
+    }
+
+    @Transactional
+    public BossRaid adminStartRaidImmediately(Long groupId) {
+        Group group = groupRepository.findById(groupId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Group not found"));
+
+        BossRaid newRaid = new BossRaid();
+        newRaid.setGroup(group);
+        newRaid.setName("Innere Schweinehund");
+        newRaid.setDurationSeconds(1800);
+        newRaid.setStatus(RaidStatus.ACTIVE);
+        newRaid.setStartedAt(Instant.now());
+        newRaid.setHealth(1);
+        newRaid.setMaxHealth(1);
+        newRaid = bossRaidRepository.save(newRaid);
+
+        List<User> members = getAliveGroupUsers(group);
+        createQuickTasksForRaid(newRaid, members);
+        int bossHealth = calculateBossHealth(newRaid, members.size());
+        newRaid.setHealth(bossHealth);
+        newRaid.setMaxHealth(bossHealth);
+        newRaid = bossRaidRepository.save(newRaid);
+
+        // Pre-accept all alive members
+        for (User member : members) {
+            RaidParticipation participation = new RaidParticipation();
+            participation.setUser(member);
+            participation.setBossRaid(newRaid);
+            participation.setAccepted(true);
+            raidParticipationRepository.save(participation);
+        }
+        // Also invite the rest of the group as pending
+        inviteAllGroupMembers(newRaid, group);
+
+        bossRaidRepository.save(newRaid);
+        broadcastRaidUpdate(newRaid);
+
+        return newRaid;
+    }
+
+    @Transactional
+    public BossRaid adminFastForwardRaid(Long raidId, int seconds) {
+        BossRaid raid = bossRaidRepository.findById(raidId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Raid not found"));
+        if (raid.getStatus() != RaidStatus.SCHEDULED) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "Only SCHEDULED raids can be fast-forwarded");
+        }
+        raid.setScheduledTime(Instant.now().plusSeconds(seconds));
+        return bossRaidRepository.save(raid);
+    }
+
+    @Transactional
+    public BossRaid adminForceCompleteRaid(Long raidId, String outcome) {
+        BossRaid raid = bossRaidRepository.findById(raidId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Raid not found"));
+        RaidStatus target = "DEFEATED".equalsIgnoreCase(outcome) ? RaidStatus.DEFEATED : RaidStatus.FAILED;
+        endRaidWithRewards(raid, target);
+        raid = bossRaidRepository.save(raid);
+        broadcastRaidUpdate(raid);
+        return raid;
+    }
+
+    @Transactional
+    public void adminClearGroupRaids(Long groupId) {
+        List<BossRaid> raids = bossRaidRepository.findByGroupId(groupId);
+        for (BossRaid raid : raids) {
+            deleteRaid(raid);
+        }
+    }
+
+    private void deleteRaid(BossRaid raid) {
+        List<RaidTask> tasks = raidTaskRepository.findByRaid(raid);
+        for (RaidTask task : tasks) {
+            raidTaskCompletionRepository.deleteAll(raidTaskCompletionRepository.findByRaidTask(task));
+        }
+        raidTaskRepository.deleteAll(tasks);
+        raidParticipationRepository.deleteAll(raidParticipationRepository.findByBossRaidId(raid.getId()));
+        bossRaidRepository.delete(raid);
+    }
+
+    private void broadcastRaidDeletion(BossRaid raid) {
+        raidLiveService.broadcastRaidUpdate(
+                raid.getId(),
+                raid.getGroup().getId(),
+                0,
+                0,
+                "DELETED",
+                List.of());
     }
 }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/RaidServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/RaidServiceTest.java
@@ -95,6 +95,7 @@ public class RaidServiceTest {
         participation = new RaidParticipation();
         participation.setUser(user);
         participation.setBossRaid(raid);
+        participation.setAccepted(true);
 
         when(userRepository.findByToken("token")).thenReturn(user);
         when(bossRaidRepository.findById(1L)).thenReturn(Optional.of(raid));
@@ -259,6 +260,8 @@ public class RaidServiceTest {
         raid.setStatus(RaidStatus.SCHEDULED);
         when(bossRaidRepository.findByStatusAndScheduledTimeBefore(eq(RaidStatus.SCHEDULED), any()))
                 .thenReturn(List.of(raid));
+        when(raidParticipationRepository.countByBossRaidIdAndAccepted(raid.getId(), true))
+                .thenReturn(2L);
 
         raidService.activateDueRaids();
 


### PR DESCRIPTION
Summary
The previous boss raid implementation lacked a clear separation between raid states, making the UX confusing and difficult to extend. This PR reworks the entire raid flow into distinct, purpose-built phases and adds admin tooling for testing and presentation.

Raid flow redesign
The RaidCard component has been replaced with a proper state machine across five dedicated screens:

- No raid: shown when a group has no upcoming or past raid
- Lobby: shown when a raid is scheduled but not yet started; members can RSVP accept or decline
- Active: animated battle view with a live boss stage, per-member HP bars, countdown timer, and real-time damage popups
- Victory / Defeat:  distinct outcome screens shown after the raid ends, with XP and MVP highlights
- Past raids: scrollable history of completed raids
clearing raids

closes  #135 