### PR TITLE
closes #141, closes #84, closes #14 Implemented dynamic dmg calculation based on time and item drop percentage

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/RaidTaskCompletion.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/entity/RaidTaskCompletion.java
@@ -25,6 +25,7 @@ public class RaidTaskCompletion {
 
     private Instant completedAt;
 
+    @PrePersist
     protected void onCreate() {
         this.completedAt = Instant.now();
     }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/RaidService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/RaidService.java
@@ -186,11 +186,21 @@ public class RaidService {
             return;
 
         RaidParticipation top = null;
+        List<Item> items = outcome == RaidStatus.DEFEATED ? itemService.getAllItems() : List.of();
         for (RaidParticipation p : participations) {
             int xp;
             if (outcome == RaidStatus.DEFEATED) {
                 xp = (p.getDamageDealt() != null ? p.getDamageDealt() : 0)
                         + (p.getTasksCompleted() != null ? p.getTasksCompleted() : 0) * 10;
+                if (!items.isEmpty() && Math.random() < 0.25) {
+                    Long userId = p.getUser().getId();
+                    int randomItem = (int)(Math.random() * items.size());
+                    Long itemId = items.get(randomItem).getId();
+                    try {
+                        itemService.grantItem(userId, itemId);
+                    } catch (ResponseStatusException ignored) {
+                    }  
+                }
             } else {
                 xp = (p.getTasksCompleted() != null ? p.getTasksCompleted() : 0) * 5;
             }
@@ -202,20 +212,7 @@ public class RaidService {
                 top = p;
             }
         }
-        if (outcome == RaidStatus.DEFEATED) {
-            List<Item> items = itemService.getAllItems();
-            for (RaidParticipation p : participations) {
-                if (!items.isEmpty() && Math.random() < 0.25) {
-                    Long userId = p.getUser().getId();
-                    int randomItem = (int)(Math.random() * items.size());
-                    Long itemId = items.get(randomItem).getId();
-                    try {
-                        itemService.grantItem(userId, itemId);
-                    } catch (ResponseStatusException ignored) {
-                    }  
-                }
-            }
-        }
+
         if (outcome == RaidStatus.DEFEATED && top != null
                 && (top.getDamageDealt() != null ? top.getDamageDealt() : 0) > 0) {
             top.setMvp(true);

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/RaidService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/RaidService.java
@@ -1,6 +1,7 @@
 package ch.uzh.ifi.hase.soprafs26.service;
 
 import java.time.Instant;
+import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -377,6 +378,22 @@ public class RaidService {
 
         if (success) {
             int damage = task.getSuccessfulDamage() != null ? task.getSuccessfulDamage() : 0;
+            List<RaidTask> tasks = raidTaskRepository.findByRaid(raid);
+            tasks.sort(Comparator.comparingInt(t -> (t.getTaskOrder() != null ? t.getTaskOrder() : 0)));
+            int windowStartSeconds = tasks.stream()
+                    .filter(t -> t.getAssignedUser().equals(task.getAssignedUser())
+                            && t.getTaskOrder() < task.getTaskOrder())
+                    .mapToInt(t -> t.getTimeLimitSeconds() != null ? t.getTimeLimitSeconds() : 0)
+                    .sum();
+            Instant taskWindowStart = raid.getStartedAt().plusSeconds(windowStartSeconds);
+            Long elapsed = Duration.between(taskWindowStart, completion.getCompletedAt()).getSeconds();
+            double timeLeftRatio = 1.0 - ((double) elapsed / task.getTimeLimitSeconds());
+            if (timeLeftRatio >= 0.75) {
+                damage = (int) (damage * 1.1);
+            } else if (timeLeftRatio >= 0.5) {
+                damage = (int) (damage * 1.05);
+            }
+
             raid.applyDamage(damage);
             participation.setTasksCompleted(participation.getTasksCompleted() + 1);
             participation.setDamageDealt(participation.getDamageDealt() + damage);

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/RaidService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/RaidService.java
@@ -21,6 +21,7 @@ import ch.uzh.ifi.hase.soprafs26.constant.RaidStatus;
 import ch.uzh.ifi.hase.soprafs26.entity.BossRaid;
 import ch.uzh.ifi.hase.soprafs26.entity.Character;
 import ch.uzh.ifi.hase.soprafs26.entity.Group;
+import ch.uzh.ifi.hase.soprafs26.entity.Item;
 import ch.uzh.ifi.hase.soprafs26.entity.RaidParticipation;
 import ch.uzh.ifi.hase.soprafs26.entity.RaidTask;
 import ch.uzh.ifi.hase.soprafs26.entity.RaidTaskCompletion;
@@ -49,6 +50,7 @@ public class RaidService {
     private final GroupRepository groupRepository;
     private final RaidLiveService raidLiveService;
     private final ch.uzh.ifi.hase.soprafs26.service.CharacterLiveService characterLiveService;
+    private final ItemService itemService;
 
     @Autowired
     public RaidService(BossRaidRepository bossRaidRepository,
@@ -58,7 +60,8 @@ public class RaidService {
             CalendarService calendarService,
             GroupRepository groupRepository,
             RaidLiveService raidLiveService,
-            ch.uzh.ifi.hase.soprafs26.service.CharacterLiveService characterLiveService) {
+            ch.uzh.ifi.hase.soprafs26.service.CharacterLiveService characterLiveService,
+            ItemService itemService) {
         this.bossRaidRepository = bossRaidRepository;
         this.raidParticipationRepository = raidParticipationRepository;
         this.userRepository = userRepository;
@@ -68,6 +71,7 @@ public class RaidService {
         this.groupRepository = groupRepository;
         this.raidLiveService = raidLiveService;
         this.characterLiveService = characterLiveService;
+        this.itemService = itemService;
     }
 
     public BossRaid createRaid(Long groupId, RaidPostDTO dto) {
@@ -196,6 +200,20 @@ public class RaidService {
                     || (p.getDamageDealt() != null ? p.getDamageDealt()
                             : 0) > (top.getDamageDealt() != null ? top.getDamageDealt() : 0)) {
                 top = p;
+            }
+        }
+        if (outcome == RaidStatus.DEFEATED) {
+            List<Item> items = itemService.getAllItems();
+            for (RaidParticipation p : participations) {
+                if (!items.isEmpty() && Math.random() < 0.25) {
+                    Long userId = p.getUser().getId();
+                    int randomItem = (int)(Math.random() * items.size());
+                    Long itemId = items.get(randomItem).getId();
+                    try {
+                        itemService.grantItem(userId, itemId);
+                    } catch (ResponseStatusException ignored) {
+                    }  
+                }
             }
         }
         if (outcome == RaidStatus.DEFEATED && top != null

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/RaidServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/RaidServiceTest.java
@@ -45,6 +45,8 @@ public class RaidServiceTest {
     private RaidLiveService raidLiveService;
     @Mock
     private CharacterLiveService characterLiveService;
+    @Mock
+    private ItemService itemService;
 
     @InjectMocks
     private RaidService raidService;
@@ -103,19 +105,26 @@ public class RaidServiceTest {
         when(raidParticipationRepository.findByBossRaidAndUser(raid, user)).thenReturn(Optional.of(participation));
         when(raidTaskCompletionRepository.findByRaidTaskAndParticipation(task, participation))
                 .thenReturn(Optional.empty());
+        when(itemService.getAllItems()).thenReturn(List.of());
+        when(raidTaskCompletionRepository.save(any())).thenAnswer(i -> {
+            RaidTaskCompletion c = i.getArgument(0);
+            c.setCompletedAt(Instant.now());
+            return c;
+        });
     }
 
     @Test
     public void completeTask_success_reducesBossHPAndTracksStats() {
         raidService.completeTask(1L, 1L, true, "token");
 
-        assertEquals(400, raid.getHealth());
+        assertEquals(390, raid.getHealth());
         assertEquals(1, participation.getTasksCompleted());
-        assertEquals(100, participation.getDamageDealt());
+        assertEquals(110, participation.getDamageDealt());
     }
 
     @Test
     public void completeTask_success_killsBoss_statusBecomesDefeated() {
+        when(raidParticipationRepository.findByBossRaidId(1L)).thenReturn(List.of(participation));
         raid.setHealth(100);
         task.setSuccessfulDamage(100);
 
@@ -325,7 +334,7 @@ public class RaidServiceTest {
     @Test
     public void expireOverdueTasks_overdueTask_autoFails() {
         raid.setStartedAt(Instant.now().minusSeconds(700));
-        
+
         when(bossRaidRepository.findByStatus(RaidStatus.ACTIVE)).thenReturn(List.of(raid));
         when(raidTaskRepository.findByRaid(raid)).thenReturn(new ArrayList<>(List.of(task)));
         when(raidTaskCompletionRepository.findByRaidTask(task)).thenReturn(List.of());


### PR DESCRIPTION
- Dynamic damage bonus based on task completion speed
   - When a player completes a raid task, the damage dealt is now multiplied by a time bonus. Completing a task in the first 25% of its allowed time grants +10% damage; within the first 50% grants +5%. This incentivises faster task completion and rewards skilled play.

- Random item drop on raid victory
  - When the raid boss is defeated, each participating player now has a 25% chance to receive a randomly selected item from the item pool. The drop is handled via the existing ItemService.grantItem flow.