### PR TITLE
feat: backend logic for group habit progress, added group edit options and tests. closes #148

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/GroupController.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/controller/GroupController.java
@@ -5,16 +5,22 @@ import java.util.List;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import ch.uzh.ifi.hase.soprafs26.entity.Group;
+import ch.uzh.ifi.hase.soprafs26.entity.Habit;
+import ch.uzh.ifi.hase.soprafs26.repository.HabitRepository;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.GroupGetDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.GroupJoinDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.GroupPostDTO;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.GroupPutDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.mapper.DTOMapper;
 import ch.uzh.ifi.hase.soprafs26.service.GroupService;
 
@@ -22,9 +28,11 @@ import ch.uzh.ifi.hase.soprafs26.service.GroupService;
 public class GroupController {
 
     private final GroupService groupService;
+    private final HabitRepository habitRepository;
 
-    public GroupController(GroupService groupService) {
+    public GroupController(GroupService groupService, HabitRepository habitRepository) {
         this.groupService = groupService;
+        this.habitRepository = habitRepository;
     }
 
     @GetMapping("/groups")
@@ -32,23 +40,62 @@ public class GroupController {
     public List<GroupGetDTO> getGroups(@CookieValue(name = "token", required = true) String tokenCookie) {
         List<Group> groups = groupService.getMyGroups(tokenCookie);
         List<GroupGetDTO> dtos = new ArrayList<>();
-    
+        // for each group, we need total and completed positive habits for each member
+        // -> for group habit progress in frontend
         for (Group g : groups) {
-            dtos.add(DTOMapper.INSTANCE.convertEntityToGroupGetDTO(g));
+            GroupGetDTO dto = DTOMapper.INSTANCE.convertEntityToGroupGetDTO(g);
+            for (GroupGetDTO.GroupMember member : dto.getUsers()) {
+                List<Habit> allHabits = habitRepository.findByUserId(member.getId());
+                List<Habit> habits = new ArrayList<>();
+                for (Habit h : allHabits) {
+                    if (Boolean.TRUE.equals(h.getPositive()))
+                        habits.add(h);
+                }
+                int completed = 0;
+                for (Habit h : habits) {
+                    if (Boolean.TRUE.equals(h.getCompleted()))
+                        completed++;
+                }
+                member.setTotalHabits(habits.size());
+                member.setCompletedHabits(completed);
+            }
+            dtos.add(dto);
         }
         return dtos;
     }
 
     @PostMapping("/groups")
     @ResponseStatus(HttpStatus.CREATED)
-    public GroupGetDTO createGroup(@RequestBody GroupPostDTO dto, @CookieValue(name = "token", required = true) String tokenCookie) {
+    public GroupGetDTO createGroup(@RequestBody GroupPostDTO dto,
+            @CookieValue(name = "token", required = true) String tokenCookie) {
         Group input = DTOMapper.INSTANCE.convertGroupPostDTOtoEntity(dto);
         return DTOMapper.INSTANCE.convertEntityToGroupGetDTO(groupService.createGroup(input, tokenCookie));
     }
 
-    @PostMapping("/groups/join") 
+    @PostMapping("/groups/join")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void joinGroup(@RequestBody GroupJoinDTO dto, @CookieValue(name = "token", required = true) String tokenCookie) {
+    public void joinGroup(@RequestBody GroupJoinDTO dto,
+            @CookieValue(name = "token", required = true) String tokenCookie) {
         groupService.joinGroup(dto.getName(), dto.getPassword(), tokenCookie);
+    }
+
+    @DeleteMapping("/groups/{id}/leave")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void leaveGroup(@PathVariable Long id, @CookieValue(name = "token", required = true) String tokenCookie) {
+        groupService.leaveGroup(id, tokenCookie);
+    }
+
+    @PutMapping("/groups/{id}")
+    @ResponseStatus(HttpStatus.OK)
+    public GroupGetDTO updateGroup(@PathVariable Long id, @RequestBody GroupPutDTO dto,
+            @CookieValue(name = "token", required = true) String tokenCookie) {
+        Group updated = groupService.updateGroup(id, dto, tokenCookie);
+        return DTOMapper.INSTANCE.convertEntityToGroupGetDTO(updated);
+    }
+
+    @DeleteMapping("/groups/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void deleteGroup(@PathVariable Long id, @CookieValue(name = "token", required = true) String tokenCookie) {
+        groupService.deleteGroup(id, tokenCookie);
     }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/GroupGetDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/GroupGetDTO.java
@@ -3,15 +3,13 @@ package ch.uzh.ifi.hase.soprafs26.rest.dto;
 import java.time.LocalDateTime;
 import java.util.List;
 
-import ch.uzh.ifi.hase.soprafs26.entity.User;
-
 public class GroupGetDTO {
 
   private Long id;
   private String name;
   private String createdBy;
   private LocalDateTime createdAt;
-  private List<User> users;
+  private List<GroupMember> users;
 
   public Long getId() {
     return id;
@@ -32,9 +30,9 @@ public class GroupGetDTO {
   public String getCreatedBy() {
     return createdBy;
   }
-  
-  public void setCreatedBy(String createdBy) { 
-    this.createdBy = createdBy; 
+
+  public void setCreatedBy(String createdBy) {
+    this.createdBy = createdBy;
   }
 
   public LocalDateTime getCreatedAt() {
@@ -45,11 +43,69 @@ public class GroupGetDTO {
     this.createdAt = createdAt;
   }
 
-  public List<User> getUsers() {
+  public List<GroupMember> getUsers() {
     return users;
   }
 
-  public void setUsers(List<User> users) {
+  public void setUsers(List<GroupMember> users) {
     this.users = users;
+  }
+
+  // inner class for group members -> needed for habit progress
+  public static class GroupMember {
+    private Long id;
+    private String username;
+    private String status;
+    private Integer level;
+    private int completedHabits;
+    private int totalHabits;
+
+    public Long getId() {
+      return id;
+    }
+
+    public void setId(Long id) {
+      this.id = id;
+    }
+
+    public String getUsername() {
+      return username;
+    }
+
+    public void setUsername(String username) {
+      this.username = username;
+    }
+
+    public String getStatus() {
+      return status;
+    }
+
+    public void setStatus(String status) {
+      this.status = status;
+    }
+
+    public Integer getLevel() {
+      return level;
+    }
+
+    public void setLevel(Integer level) {
+      this.level = level;
+    }
+
+    public int getCompletedHabits() {
+      return completedHabits;
+    }
+
+    public void setCompletedHabits(int completedHabits) {
+      this.completedHabits = completedHabits;
+    }
+
+    public int getTotalHabits() {
+      return totalHabits;
+    }
+
+    public void setTotalHabits(int totalHabits) {
+      this.totalHabits = totalHabits;
+    }
   }
 }

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/GroupPutDTO.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/dto/GroupPutDTO.java
@@ -1,0 +1,22 @@
+package ch.uzh.ifi.hase.soprafs26.rest.dto;
+
+public class GroupPutDTO {
+    private String name;
+    private String password;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+}

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/mapper/DTOMapper.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/rest/mapper/DTOMapper.java
@@ -117,6 +117,12 @@ public interface DTOMapper {
 	Group convertGroupPostDTOtoEntity(GroupPostDTO groupPostDTO);
 
 	@Mapping(source = "id", target = "id")
+	@Mapping(source = "username", target = "username")
+	@Mapping(source = "status", target = "status")
+	@Mapping(source = "character.level", target = "level")
+	GroupGetDTO.GroupMember convertUserToGroupMember(User user);
+
+	@Mapping(source = "id", target = "id")
 	@Mapping(source = "name", target = "name")
 	@Mapping(source = "createdBy", target = "createdBy")
 	@Mapping(source = "createdAt", target = "createdAt")

--- a/src/main/java/ch/uzh/ifi/hase/soprafs26/service/GroupService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs26/service/GroupService.java
@@ -13,17 +13,18 @@ import ch.uzh.ifi.hase.soprafs26.entity.Group;
 import ch.uzh.ifi.hase.soprafs26.entity.User;
 import ch.uzh.ifi.hase.soprafs26.repository.GroupRepository;
 import ch.uzh.ifi.hase.soprafs26.repository.UserRepository;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.GroupPutDTO;
 
 @Service
 @Transactional
 public class GroupService {
 
   private final GroupRepository groupRepository;
-  private final UserRepository userRepository; 
+  private final UserRepository userRepository;
 
   public GroupService(GroupRepository groupRepository, UserRepository userRepository) {
     this.groupRepository = groupRepository;
-    this.userRepository = userRepository; 
+    this.userRepository = userRepository;
   }
 
   public Group createGroup(Group newGroup, String token) {
@@ -38,12 +39,12 @@ public class GroupService {
 
     newGroup.setCreatedBy(creator.getUsername());
     newGroup.setCreatedAt(LocalDateTime.now());
-        
-    Group savedGroup = groupRepository.save(newGroup); 
-        
+
+    Group savedGroup = groupRepository.save(newGroup);
+
     creator.addGroup(savedGroup);
     userRepository.save(creator);
-        
+
     return savedGroup;
   }
 
@@ -64,7 +65,7 @@ public class GroupService {
 
     if (user.getGroups().contains(group)) {
       throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "You are already a member of this group.");
-    } 
+    }
 
     user.addGroup(group);
     userRepository.save(user);
@@ -72,12 +73,67 @@ public class GroupService {
     return group;
   }
 
+  public void leaveGroup(Long groupId, String token) {
+    User user = userRepository.findByToken(token);
+    if (user == null)
+      throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Session expired.");
+
+    Group group = groupRepository.findById(groupId)
+        .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Group not found."));
+
+    if (group.getCreatedBy().equals(user.getUsername()))
+      throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Owner cannot leave. Delete the group instead.");
+
+    if (!user.getGroups().contains(group))
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "You are not a member of this group.");
+
+    user.removeGroup(group);
+    userRepository.save(user);
+  }
+
+  public Group updateGroup(Long groupId, GroupPutDTO dto, String token) {
+    User owner = userRepository.findByToken(token);
+    if (owner == null)
+      throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Session expired.");
+
+    Group group = groupRepository.findById(groupId)
+        .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Group not found."));
+
+    if (!group.getCreatedBy().equals(owner.getUsername()))
+      throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Only the owner can edit this group.");
+
+    if (dto.getName() != null && !dto.getName().isBlank())
+      group.setName(dto.getName());
+    if (dto.getPassword() != null && !dto.getPassword().isBlank())
+      group.setPassword(dto.getPassword());
+
+    return groupRepository.save(group);
+  }
+
+  public void deleteGroup(Long groupId, String token) {
+    User owner = userRepository.findByToken(token);
+    if (owner == null)
+      throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Session expired.");
+
+    Group group = groupRepository.findById(groupId)
+        .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Group not found."));
+
+    if (!group.getCreatedBy().equals(owner.getUsername()))
+      throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Only the owner can delete this group.");
+
+    for (User u : new java.util.HashSet<>(group.getUsers())) {
+      u.getGroups().remove(group);
+      userRepository.save(u);
+    }
+    groupRepository.delete(group);
+  }
+
   public List<Group> getMyGroups(String token) {
     User user = userRepository.findByToken(token);
     if (user == null) {
       throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Session expired.");
     }
-        
+
     return new ArrayList<>(user.getGroups());
   }
 }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/AchievementControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/AchievementControllerTest.java
@@ -1,0 +1,102 @@
+package ch.uzh.ifi.hase.soprafs26.controller;
+
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import org.junit.jupiter.api.Test;
+import static org.mockito.BDDMockito.given;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import org.springframework.web.server.ResponseStatusException;
+
+import ch.uzh.ifi.hase.soprafs26.constant.AchievementKey;
+import ch.uzh.ifi.hase.soprafs26.entity.Achievement;
+import ch.uzh.ifi.hase.soprafs26.entity.CharacterAchievement;
+import ch.uzh.ifi.hase.soprafs26.entity.User;
+import ch.uzh.ifi.hase.soprafs26.service.AchievementService;
+import ch.uzh.ifi.hase.soprafs26.service.UserService;
+import jakarta.servlet.http.Cookie;
+
+@WebMvcTest(AchievementController.class)
+public class AchievementControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private AchievementService achievementService;
+
+    @MockitoBean
+    private UserService userService;
+
+    private CharacterAchievement buildCharacterAchievement() {
+        Achievement a = new Achievement();
+        a.setId(1L);
+        a.setKey(AchievementKey.FIRST_HABIT);
+        a.setName("Baby Steps");
+        a.setDescription("Complete your first habit");
+        a.setIcon("first_habit");
+
+        CharacterAchievement ca = new CharacterAchievement();
+        ca.setId(1L);
+        ca.setAchievement(a);
+        ca.setEarnedAt(Instant.now());
+        return ca;
+    }
+
+    @Test
+    public void getAchievements_validToken_returnsAchievementList() throws Exception {
+        User user = new User();
+        user.setId(1L);
+        user.setUsername("testUser");
+
+        CharacterAchievement ca = buildCharacterAchievement();
+
+        given(userService.getUserByToken("token")).willReturn(user);
+        given(achievementService.getAchievementsForUser(1L)).willReturn(List.of(ca));
+
+        mockMvc.perform(get("/users/1/achievements")
+                .cookie(new Cookie("token", "token"))
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].key", is("FIRST_HABIT")))
+                .andExpect(jsonPath("$[0].name", is("Baby Steps")));
+    }
+
+    @Test
+    public void getAchievements_emptyList_returnsEmptyArray() throws Exception {
+        User user = new User();
+        user.setId(1L);
+        user.setUsername("testUser");
+
+        given(userService.getUserByToken("token")).willReturn(user);
+        given(achievementService.getAchievementsForUser(1L)).willReturn(Collections.emptyList());
+
+        mockMvc.perform(get("/users/1/achievements")
+                .cookie(new Cookie("token", "token"))
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(0)));
+    }
+
+    @Test
+    public void getAchievements_invalidToken_returnsUnauthorized() throws Exception {
+        given(userService.getUserByToken("bad-token"))
+                .willThrow(new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Session expired."));
+
+        mockMvc.perform(get("/users/1/achievements")
+                .cookie(new Cookie("token", "bad-token"))
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isUnauthorized());
+    }
+}

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/GroupControllerTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/controller/GroupControllerTest.java
@@ -2,12 +2,14 @@ package ch.uzh.ifi.hase.soprafs26.controller;
 
 import java.time.LocalDateTime;
 import java.util.Collections;
+import java.util.List;
 
 import static org.hamcrest.Matchers.is;
 import org.junit.jupiter.api.Test;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
@@ -16,15 +18,24 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import org.springframework.web.server.ResponseStatusException;
 
+import ch.uzh.ifi.hase.soprafs26.constant.HabitCategory;
+import ch.uzh.ifi.hase.soprafs26.constant.HabitFrequency;
+import ch.uzh.ifi.hase.soprafs26.constant.UserStatus;
 import ch.uzh.ifi.hase.soprafs26.entity.Group;
+import ch.uzh.ifi.hase.soprafs26.entity.Habit;
+import ch.uzh.ifi.hase.soprafs26.entity.User;
+import ch.uzh.ifi.hase.soprafs26.repository.HabitRepository;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.GroupJoinDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.GroupPostDTO;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.GroupPutDTO;
 import ch.uzh.ifi.hase.soprafs26.service.GroupService;
 import jakarta.servlet.http.Cookie;
 import tools.jackson.core.JacksonException;
@@ -33,80 +44,253 @@ import tools.jackson.databind.ObjectMapper;
 @WebMvcTest(GroupController.class)
 public class GroupControllerTest {
 
-    @Autowired
-    private MockMvc mockMvc;
+        @Autowired
+        private MockMvc mockMvc;
 
-    @MockitoBean
-    private GroupService groupService;
+        @MockitoBean
+        private GroupService groupService;
 
-    @Test
-    public void givenGroups_whenGetGroups_thenReturnJsonArray() throws Exception {
-        Group group = new Group();
-        group.setId(1L);
-        group.setName("Test Group");
-        group.setCreatedBy("creator");
-        group.setCreatedAt(LocalDateTime.now());
+        @MockitoBean
+        private HabitRepository habitRepository;
 
-        given(groupService.getMyGroups("token")).willReturn(Collections.singletonList(group));
+        @Test
+        public void givenGroups_whenGetGroups_thenReturnJsonArray() throws Exception {
+                Group group = new Group();
+                group.setId(1L);
+                group.setName("Test Group");
+                group.setCreatedBy("creator");
+                group.setCreatedAt(LocalDateTime.now());
 
-        MockHttpServletRequestBuilder getRequest = get("/groups")
-                .cookie(new Cookie("token", "token"))
-                .contentType(MediaType.APPLICATION_JSON);
+                given(groupService.getMyGroups("token")).willReturn(Collections.singletonList(group));
 
-        mockMvc.perform(getRequest)
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$[0].id", is(1)))
-                .andExpect(jsonPath("$[0].name", is("Test Group")))
-                .andExpect(jsonPath("$[0].createdBy", is("creator")));
-    }
+                MockHttpServletRequestBuilder getRequest = get("/groups")
+                                .cookie(new Cookie("token", "token"))
+                                .contentType(MediaType.APPLICATION_JSON);
 
-    @Test
-    public void createGroup_validInput_returnsCreatedGroup() throws Exception {
-        GroupPostDTO dto = new GroupPostDTO();
-        dto.setName("Test Group");
-        dto.setPassword("secret");
-
-        Group createdGroup = new Group();
-        createdGroup.setId(1L);
-        createdGroup.setName("Test Group");
-        createdGroup.setCreatedBy("creator");
-        createdGroup.setCreatedAt(LocalDateTime.now());
-
-        given(groupService.createGroup(any(Group.class), eq("token"))).willReturn(createdGroup);
-
-        MockHttpServletRequestBuilder postRequest = post("/groups").cookie(new Cookie("token", "token"))
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(asJsonString(dto));
-
-        mockMvc.perform(postRequest)
-                .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.id", is(1)))
-                .andExpect(jsonPath("$.name", is("Test Group")))
-                .andExpect(jsonPath("$.createdBy", is("creator")));
-    }
-
-    @Test
-    public void joinGroup_validInput_returnsNoContent() throws Exception {
-        GroupJoinDTO dto = new GroupJoinDTO();
-        dto.setName("Test Group");
-        dto.setPassword("secret");
-
-        MockHttpServletRequestBuilder postRequest = post("/groups/join")
-                .cookie(new Cookie("token", "token"))
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(asJsonString(dto));
-
-        mockMvc.perform(postRequest).andExpect(status().isNoContent());
-
-        verify(groupService).joinGroup("Test Group", "secret", "token");
-    }
-
-    private String asJsonString(final Object object) {
-        try {
-            return new ObjectMapper().writeValueAsString(object);
-        } catch (JacksonException e) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
-                    String.format("The request body could not be created.%s", e.toString()));
+                mockMvc.perform(getRequest)
+                                .andExpect(status().isOk())
+                                .andExpect(jsonPath("$[0].id", is(1)))
+                                .andExpect(jsonPath("$[0].name", is("Test Group")))
+                                .andExpect(jsonPath("$[0].createdBy", is("creator")));
         }
-    }
+
+        @Test
+        public void createGroup_validInput_returnsCreatedGroup() throws Exception {
+                GroupPostDTO dto = new GroupPostDTO();
+                dto.setName("Test Group");
+                dto.setPassword("secret");
+
+                Group createdGroup = new Group();
+                createdGroup.setId(1L);
+                createdGroup.setName("Test Group");
+                createdGroup.setCreatedBy("creator");
+                createdGroup.setCreatedAt(LocalDateTime.now());
+
+                given(groupService.createGroup(any(Group.class), eq("token"))).willReturn(createdGroup);
+
+                MockHttpServletRequestBuilder postRequest = post("/groups").cookie(new Cookie("token", "token"))
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(asJsonString(dto));
+
+                mockMvc.perform(postRequest)
+                                .andExpect(status().isCreated())
+                                .andExpect(jsonPath("$.id", is(1)))
+                                .andExpect(jsonPath("$.name", is("Test Group")))
+                                .andExpect(jsonPath("$.createdBy", is("creator")));
+        }
+
+        @Test
+        public void joinGroup_validInput_returnsNoContent() throws Exception {
+                GroupJoinDTO dto = new GroupJoinDTO();
+                dto.setName("Test Group");
+                dto.setPassword("secret");
+
+                MockHttpServletRequestBuilder postRequest = post("/groups/join")
+                                .cookie(new Cookie("token", "token"))
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(asJsonString(dto));
+
+                mockMvc.perform(postRequest).andExpect(status().isNoContent());
+
+                verify(groupService).joinGroup("Test Group", "secret", "token");
+        }
+
+        @Test
+        public void getGroups_withPositiveHabits_returnsCorrectCounts() throws Exception {
+                User member = new User();
+                member.setId(10L);
+                member.setUsername("alice");
+                member.setStatus(UserStatus.ONLINE);
+
+                Group group = new Group();
+                group.setId(1L);
+                group.setName("Test Group");
+                group.setCreatedBy("creator");
+                group.setCreatedAt(LocalDateTime.now());
+                group.getUsers().add(member);
+
+                Habit completedHabit = new Habit();
+                completedHabit.setId(1L);
+                completedHabit.setTitle("Run");
+                completedHabit.setCategory(HabitCategory.PHYSICAL);
+                completedHabit.setFrequency(HabitFrequency.DAILY);
+                completedHabit.setPositive(true);
+                completedHabit.setCompleted(true);
+                completedHabit.setStreak(1);
+
+                Habit incompleteHabit = new Habit();
+                incompleteHabit.setId(2L);
+                incompleteHabit.setTitle("Meditate");
+                incompleteHabit.setCategory(HabitCategory.EMOTIONAL);
+                incompleteHabit.setFrequency(HabitFrequency.DAILY);
+                incompleteHabit.setPositive(true);
+                incompleteHabit.setCompleted(false);
+                incompleteHabit.setStreak(0);
+
+                given(groupService.getMyGroups("token")).willReturn(Collections.singletonList(group));
+                given(habitRepository.findByUserId(10L)).willReturn(List.of(completedHabit, incompleteHabit));
+
+                mockMvc.perform(get("/groups")
+                                .cookie(new Cookie("token", "token"))
+                                .contentType(MediaType.APPLICATION_JSON))
+                                .andExpect(status().isOk())
+                                .andExpect(jsonPath("$[0].users[0].completedHabits", is(1)))
+                                .andExpect(jsonPath("$[0].users[0].totalHabits", is(2)));
+        }
+
+        @Test
+        public void leaveGroup_validInput_returnsNoContent() throws Exception {
+                mockMvc.perform(delete("/groups/1/leave")
+                                .cookie(new Cookie("token", "token"))
+                                .contentType(MediaType.APPLICATION_JSON))
+                                .andExpect(status().isNoContent());
+
+                verify(groupService).leaveGroup(1L, "token");
+        }
+
+        @Test
+        public void leaveGroup_ownerCannotLeave_returnsForbidden() throws Exception {
+                doThrow(new ResponseStatusException(HttpStatus.FORBIDDEN, "Owner cannot leave."))
+                                .when(groupService).leaveGroup(1L, "token");
+
+                mockMvc.perform(delete("/groups/1/leave")
+                                .cookie(new Cookie("token", "token"))
+                                .contentType(MediaType.APPLICATION_JSON))
+                                .andExpect(status().isForbidden());
+        }
+
+        @Test
+        public void leaveGroup_unauthorized_returnsUnauthorized() throws Exception {
+                doThrow(new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Session expired."))
+                                .when(groupService).leaveGroup(1L, "token");
+
+                mockMvc.perform(delete("/groups/1/leave")
+                                .cookie(new Cookie("token", "token"))
+                                .contentType(MediaType.APPLICATION_JSON))
+                                .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        public void leaveGroup_groupNotFound_returnsNotFound() throws Exception {
+                doThrow(new ResponseStatusException(HttpStatus.NOT_FOUND, "Group not found."))
+                                .when(groupService).leaveGroup(1L, "token");
+
+                mockMvc.perform(delete("/groups/1/leave")
+                                .cookie(new Cookie("token", "token"))
+                                .contentType(MediaType.APPLICATION_JSON))
+                                .andExpect(status().isNotFound());
+        }
+
+        @Test
+        public void updateGroup_validOwner_returnsUpdatedGroup() throws Exception {
+                GroupPutDTO dto = new GroupPutDTO();
+                dto.setName("New Name");
+
+                Group updatedGroup = new Group();
+                updatedGroup.setId(1L);
+                updatedGroup.setName("New Name");
+                updatedGroup.setCreatedBy("creator");
+                updatedGroup.setCreatedAt(LocalDateTime.now());
+
+                given(groupService.updateGroup(eq(1L), any(GroupPutDTO.class), eq("token"))).willReturn(updatedGroup);
+
+                mockMvc.perform(put("/groups/1")
+                                .cookie(new Cookie("token", "token"))
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(asJsonString(dto)))
+                                .andExpect(status().isOk())
+                                .andExpect(jsonPath("$.name", is("New Name")));
+        }
+
+        @Test
+        public void updateGroup_notOwner_returnsForbidden() throws Exception {
+                GroupPutDTO dto = new GroupPutDTO();
+                dto.setName("New Name");
+
+                given(groupService.updateGroup(eq(1L), any(GroupPutDTO.class), eq("token")))
+                                .willThrow(new ResponseStatusException(HttpStatus.FORBIDDEN,
+                                                "Only the owner can edit this group."));
+
+                mockMvc.perform(put("/groups/1")
+                                .cookie(new Cookie("token", "token"))
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(asJsonString(dto)))
+                                .andExpect(status().isForbidden());
+        }
+
+        @Test
+        public void updateGroup_groupNotFound_returnsNotFound() throws Exception {
+                GroupPutDTO dto = new GroupPutDTO();
+                dto.setName("New Name");
+
+                given(groupService.updateGroup(eq(1L), any(GroupPutDTO.class), eq("token")))
+                                .willThrow(new ResponseStatusException(HttpStatus.NOT_FOUND, "Group not found."));
+
+                mockMvc.perform(put("/groups/1")
+                                .cookie(new Cookie("token", "token"))
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(asJsonString(dto)))
+                                .andExpect(status().isNotFound());
+        }
+
+        @Test
+        public void deleteGroup_validOwner_returnsNoContent() throws Exception {
+                mockMvc.perform(delete("/groups/1")
+                                .cookie(new Cookie("token", "token"))
+                                .contentType(MediaType.APPLICATION_JSON))
+                                .andExpect(status().isNoContent());
+
+                verify(groupService).deleteGroup(1L, "token");
+        }
+
+        @Test
+        public void deleteGroup_notOwner_returnsForbidden() throws Exception {
+                doThrow(new ResponseStatusException(HttpStatus.FORBIDDEN, "Only the owner can delete this group."))
+                                .when(groupService).deleteGroup(1L, "token");
+
+                mockMvc.perform(delete("/groups/1")
+                                .cookie(new Cookie("token", "token"))
+                                .contentType(MediaType.APPLICATION_JSON))
+                                .andExpect(status().isForbidden());
+        }
+
+        @Test
+        public void deleteGroup_groupNotFound_returnsNotFound() throws Exception {
+                doThrow(new ResponseStatusException(HttpStatus.NOT_FOUND, "Group not found."))
+                                .when(groupService).deleteGroup(1L, "token");
+
+                mockMvc.perform(delete("/groups/1")
+                                .cookie(new Cookie("token", "token"))
+                                .contentType(MediaType.APPLICATION_JSON))
+                                .andExpect(status().isNotFound());
+        }
+
+        private String asJsonString(final Object object) {
+                try {
+                        return new ObjectMapper().writeValueAsString(object);
+                } catch (JacksonException e) {
+                        throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                                        String.format("The request body could not be created.%s", e.toString()));
+                }
+        }
 }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/repository/GroupRepositoryIntegrationTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/repository/GroupRepositoryIntegrationTest.java
@@ -1,7 +1,12 @@
 package ch.uzh.ifi.hase.soprafs26.repository;
 
+import java.time.LocalDateTime;
+import java.util.Optional;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
@@ -34,5 +39,51 @@ public class GroupRepositoryIntegrationTest {
         assertEquals(group.getName(), found.getName());
         assertEquals(group.getPassword(), found.getPassword());
         assertEquals(group.getCreatedBy(), found.getCreatedBy());
+    }
+
+    @Test
+    public void findByName_nonExistent_returnsNull() {
+        Group found = groupRepository.findByName("DoesNotExist");
+
+        assertNull(found);
+    }
+
+    @Test
+    public void saveGroup_persistsAllFields() {
+        LocalDateTime now = LocalDateTime.now();
+
+        Group group = new Group();
+        group.setName("Persist Group");
+        group.setPassword("pass123");
+        group.setCreatedBy("owner");
+        group.setCreatedAt(now);
+
+        entityManager.persist(group);
+        entityManager.flush();
+        entityManager.clear();
+
+        Optional<Group> found = groupRepository.findById(group.getId());
+
+        assertTrue(found.isPresent());
+        assertEquals("Persist Group", found.get().getName());
+        assertEquals("pass123", found.get().getPassword());
+        assertEquals("owner", found.get().getCreatedBy());
+        assertNotNull(found.get().getCreatedAt());
+    }
+
+    @Test
+    public void findById_existingGroup_returnsGroup() {
+        Group group = new Group();
+        group.setName("Find By Id Group");
+        group.setPassword("secret");
+        group.setCreatedBy("testOwner");
+
+        entityManager.persist(group);
+        entityManager.flush();
+
+        Optional<Group> found = groupRepository.findById(group.getId());
+
+        assertTrue(found.isPresent());
+        assertEquals("Find By Id Group", found.get().getName());
     }
 }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/rest/mapper/DTOMapperTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/rest/mapper/DTOMapperTest.java
@@ -3,11 +3,18 @@ package ch.uzh.ifi.hase.soprafs26.rest.mapper;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.junit.jupiter.api.Test;
 
+import ch.uzh.ifi.hase.soprafs26.constant.HabitCategory;
+import ch.uzh.ifi.hase.soprafs26.constant.HabitFrequency;
 import ch.uzh.ifi.hase.soprafs26.constant.UserStatus;
+import ch.uzh.ifi.hase.soprafs26.entity.Character;
 import ch.uzh.ifi.hase.soprafs26.entity.Group;
+import ch.uzh.ifi.hase.soprafs26.entity.Habit;
+import ch.uzh.ifi.hase.soprafs26.entity.Todo;
 import ch.uzh.ifi.hase.soprafs26.entity.User;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.GroupGetDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.GroupPostDTO;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.HabitGetDTO;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.TodoGetDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.UserGetDTO;
 import ch.uzh.ifi.hase.soprafs26.rest.dto.UserPostDTO;
 
@@ -84,5 +91,66 @@ public class DTOMapperTest {
 		assertEquals(group.getName(), groupGetDTO.getName());
 		assertEquals(group.getCreatedBy(), groupGetDTO.getCreatedBy());
 		assertEquals(group.getUsers().size(), groupGetDTO.getUsers().size());
+	}
+
+	@Test
+	public void testConvertUserToGroupMember_mapsAllFields() {
+		Character character = new Character();
+		character.setLevel(3);
+
+		User user = new User();
+		user.setId(5L);
+		user.setUsername("alice");
+		user.setStatus(UserStatus.ONLINE);
+		user.setCharacter(character);
+
+		GroupGetDTO.GroupMember member = DTOMapper.INSTANCE.convertUserToGroupMember(user);
+
+		assertEquals(5L, member.getId());
+		assertEquals("alice", member.getUsername());
+		assertEquals("ONLINE", member.getStatus());
+		assertEquals(3, member.getLevel());
+	}
+
+	@Test
+	public void testConvertHabit_toHabitGetDTO_mapsAllFields() {
+		Habit habit = new Habit();
+		habit.setId(1L);
+		habit.setTitle("Morning Run");
+		habit.setCategory(HabitCategory.PHYSICAL);
+		habit.setFrequency(HabitFrequency.DAILY);
+		habit.setPositive(true);
+		habit.setWeight(2);
+		habit.setCompleted(false);
+		habit.setStreak(5);
+
+		HabitGetDTO dto = DTOMapper.INSTANCE.convertEntityToHabitGetDTO(habit);
+
+		assertEquals(1L, dto.getId());
+		assertEquals("Morning Run", dto.getTitle());
+		assertEquals(HabitCategory.PHYSICAL, dto.getCategory());
+		assertEquals(HabitFrequency.DAILY, dto.getFrequency());
+		assertEquals(true, dto.getPositive());
+		assertEquals(2, dto.getWeight());
+		assertEquals(false, dto.getCompleted());
+		assertEquals(5, dto.getStreak());
+	}
+
+	@Test
+	public void testConvertTodo_toTodoGetDTO_mapsAllFields() {
+		Todo todo = new Todo();
+		todo.setId(2L);
+		todo.setTitle("Buy groceries");
+		todo.setCategory(HabitCategory.COGNITIVE);
+		todo.setWeight(1);
+		todo.setCompleted(false);
+
+		TodoGetDTO dto = DTOMapper.INSTANCE.convertEntityToTodoGetDTO(todo);
+
+		assertEquals(2L, dto.getId());
+		assertEquals("Buy groceries", dto.getTitle());
+		assertEquals(HabitCategory.COGNITIVE, dto.getCategory());
+		assertEquals(1, dto.getWeight());
+		assertEquals(false, dto.getCompleted());
 	}
 }

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/AchievementServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/AchievementServiceTest.java
@@ -1,0 +1,184 @@
+package ch.uzh.ifi.hase.soprafs26.service;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import static org.mockito.ArgumentMatchers.any;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import org.mockito.MockitoAnnotations;
+
+import ch.uzh.ifi.hase.soprafs26.constant.AchievementKey;
+import ch.uzh.ifi.hase.soprafs26.entity.Achievement;
+import ch.uzh.ifi.hase.soprafs26.entity.Character;
+import ch.uzh.ifi.hase.soprafs26.entity.CharacterAchievement;
+import ch.uzh.ifi.hase.soprafs26.repository.AchievementRepository;
+import ch.uzh.ifi.hase.soprafs26.repository.CharacterAchievementRepository;
+import ch.uzh.ifi.hase.soprafs26.repository.CharacterRepository;
+
+public class AchievementServiceTest {
+
+    @Mock
+    private AchievementRepository achievementRepository;
+
+    @Mock
+    private CharacterAchievementRepository characterAchievementRepository;
+
+    @Mock
+    private CharacterRepository characterRepository;
+
+    @InjectMocks
+    private AchievementService achievementService;
+
+    private Character testCharacter;
+    private Achievement testAchievement;
+
+    @BeforeEach
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+
+        testCharacter = new Character();
+        testCharacter.setId(1L);
+
+        testAchievement = new Achievement();
+        testAchievement.setId(1L);
+        testAchievement.setKey(AchievementKey.FIRST_HABIT);
+        testAchievement.setName("Baby Steps");
+        testAchievement.setDescription("Complete your first habit");
+        testAchievement.setIcon("first_habit");
+
+        when(characterRepository.findByUserId(1L)).thenReturn(testCharacter);
+        when(achievementRepository.findByKey(any())).thenReturn(Optional.of(testAchievement));
+        when(characterAchievementRepository.existsByCharacterAndAchievement(any(), any())).thenReturn(false);
+    }
+
+    @Test
+    public void checkHabitAchievements_characterNotFound_doesNothing() {
+        when(characterRepository.findByUserId(1L)).thenReturn(null);
+
+        achievementService.checkHabitAchievements(1L, 0);
+
+        verify(characterAchievementRepository, never()).save(any());
+    }
+
+    @Test
+    public void checkHabitAchievements_firstHabit_awardsAchievement() {
+        achievementService.checkHabitAchievements(1L, 0);
+
+        verify(characterAchievementRepository, times(1)).save(any());
+    }
+
+    @Test
+    public void checkHabitAchievements_alreadyHasAchievement_doesNotSaveAgain() {
+        when(characterAchievementRepository.existsByCharacterAndAchievement(any(), any())).thenReturn(true);
+
+        achievementService.checkHabitAchievements(1L, 0);
+
+        verify(characterAchievementRepository, never()).save(any());
+    }
+
+    @Test
+    public void checkHabitAchievements_streak3_awardsTwoAchievements() {
+        Achievement streak3Achievement = new Achievement();
+        streak3Achievement.setId(2L);
+        streak3Achievement.setKey(AchievementKey.STREAK_3);
+        streak3Achievement.setName("On a Roll");
+        streak3Achievement.setDescription("Maintain a 3-day streak on any habit");
+        streak3Achievement.setIcon("streak_3");
+
+        when(achievementRepository.findByKey(AchievementKey.FIRST_HABIT)).thenReturn(Optional.of(testAchievement));
+        when(achievementRepository.findByKey(AchievementKey.STREAK_3)).thenReturn(Optional.of(streak3Achievement));
+
+        achievementService.checkHabitAchievements(1L, 3);
+
+        verify(characterAchievementRepository, times(2)).save(any());
+    }
+
+    @Test
+    public void checkHabitAchievements_streak7_awardsThreeAchievements() {
+        Achievement streak3Achievement = new Achievement();
+        streak3Achievement.setId(2L);
+        streak3Achievement.setKey(AchievementKey.STREAK_3);
+        streak3Achievement.setName("On a Roll");
+        streak3Achievement.setDescription("Maintain a 3-day streak on any habit");
+        streak3Achievement.setIcon("streak_3");
+
+        Achievement streak7Achievement = new Achievement();
+        streak7Achievement.setId(3L);
+        streak7Achievement.setKey(AchievementKey.STREAK_7);
+        streak7Achievement.setName("Unstoppable");
+        streak7Achievement.setDescription("Maintain a 7-day streak on any habit");
+        streak7Achievement.setIcon("streak_7");
+
+        when(achievementRepository.findByKey(AchievementKey.FIRST_HABIT)).thenReturn(Optional.of(testAchievement));
+        when(achievementRepository.findByKey(AchievementKey.STREAK_3)).thenReturn(Optional.of(streak3Achievement));
+        when(achievementRepository.findByKey(AchievementKey.STREAK_7)).thenReturn(Optional.of(streak7Achievement));
+
+        achievementService.checkHabitAchievements(1L, 7);
+
+        verify(characterAchievementRepository, times(3)).save(any());
+    }
+
+    @Test
+    public void checkStatAchievements_below25_doesNotAward() {
+        achievementService.checkStatAchievements(1L, AchievementKey.STRENGTH_25, 24);
+
+        verify(characterAchievementRepository, never()).save(any());
+    }
+
+    @Test
+    public void checkStatAchievements_at25_awardsAchievement() {
+        Achievement strength25 = new Achievement();
+        strength25.setId(4L);
+        strength25.setKey(AchievementKey.STRENGTH_25);
+        strength25.setName("Emerging Warrior");
+        strength25.setDescription("Reach 25 Strength");
+        strength25.setIcon("strength_25");
+
+        when(achievementRepository.findByKey(AchievementKey.STRENGTH_25)).thenReturn(Optional.of(strength25));
+
+        achievementService.checkStatAchievements(1L, AchievementKey.STRENGTH_25, 25);
+
+        verify(characterAchievementRepository, times(1)).save(any());
+    }
+
+    @Test
+    public void checkStatAchievements_characterNotFound_doesNothing() {
+        when(characterRepository.findByUserId(1L)).thenReturn(null);
+
+        achievementService.checkStatAchievements(1L, AchievementKey.STRENGTH_25, 25);
+
+        verify(characterAchievementRepository, never()).save(any());
+    }
+
+    @Test
+    public void getAchievementsForUser_characterNotFound_returnsEmpty() {
+        when(characterRepository.findByUserId(1L)).thenReturn(null);
+
+        List<CharacterAchievement> result = achievementService.getAchievementsForUser(1L);
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void getAchievementsForUser_returnsAchievements() {
+        CharacterAchievement ca = new CharacterAchievement();
+        ca.setId(1L);
+        ca.setCharacter(testCharacter);
+        ca.setAchievement(testAchievement);
+
+        when(characterAchievementRepository.findByCharacter(testCharacter)).thenReturn(List.of(ca));
+
+        List<CharacterAchievement> result = achievementService.getAchievementsForUser(1L);
+
+        assertEquals(1, result.size());
+    }
+}

--- a/src/test/java/ch/uzh/ifi/hase/soprafs26/service/GroupServiceTest.java
+++ b/src/test/java/ch/uzh/ifi/hase/soprafs26/service/GroupServiceTest.java
@@ -2,8 +2,10 @@ package ch.uzh.ifi.hase.soprafs26.service;
 
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import org.junit.jupiter.api.BeforeEach;
@@ -20,6 +22,7 @@ import ch.uzh.ifi.hase.soprafs26.entity.Group;
 import ch.uzh.ifi.hase.soprafs26.entity.User;
 import ch.uzh.ifi.hase.soprafs26.repository.GroupRepository;
 import ch.uzh.ifi.hase.soprafs26.repository.UserRepository;
+import ch.uzh.ifi.hase.soprafs26.rest.dto.GroupPutDTO;
 
 public class GroupServiceTest {
 
@@ -157,5 +160,181 @@ public class GroupServiceTest {
     when(userRepository.findByToken("somethingInvalid")).thenReturn(null);
 
     assertThrows(ResponseStatusException.class, () -> groupService.getMyGroups("somethingInvalid"));
+  }
+
+  @Test
+  public void leaveGroup_validInput_removesUserFromGroup() {
+    Group existingGroup = new Group();
+    existingGroup.setId(2L);
+    existingGroup.setName("Test Group");
+    existingGroup.setPassword("secret");
+    existingGroup.setCreatedBy("other");
+
+    groupOwner.addGroup(existingGroup);
+
+    when(groupRepository.findById(2L)).thenReturn(Optional.of(existingGroup));
+
+    groupService.leaveGroup(2L, "token");
+
+    verify(userRepository).save(groupOwner);
+    assertFalse(groupOwner.getGroups().contains(existingGroup));
+  }
+
+  @Test
+  public void leaveGroup_invalidToken_throwsUnauthorized() {
+    when(userRepository.findByToken("bad")).thenReturn(null);
+
+    assertThrows(ResponseStatusException.class, () -> groupService.leaveGroup(2L, "bad"));
+  }
+
+  @Test
+  public void leaveGroup_groupNotFound_throwsNotFound() {
+    when(groupRepository.findById(99L)).thenReturn(Optional.empty());
+
+    assertThrows(ResponseStatusException.class, () -> groupService.leaveGroup(99L, "token"));
+  }
+
+  @Test
+  public void leaveGroup_ownerCannotLeave_throwsForbidden() {
+    Group existingGroup = new Group();
+    existingGroup.setId(2L);
+    existingGroup.setName("Test Group");
+    existingGroup.setPassword("secret");
+    existingGroup.setCreatedBy("creator");
+
+    groupOwner.addGroup(existingGroup);
+
+    when(groupRepository.findById(2L)).thenReturn(Optional.of(existingGroup));
+
+    assertThrows(ResponseStatusException.class, () -> groupService.leaveGroup(2L, "token"));
+  }
+
+  @Test
+  public void leaveGroup_notMember_throwsBadRequest() {
+    Group existingGroup = new Group();
+    existingGroup.setId(2L);
+    existingGroup.setName("Test Group");
+    existingGroup.setPassword("secret");
+    existingGroup.setCreatedBy("other");
+
+    when(groupRepository.findById(2L)).thenReturn(Optional.of(existingGroup));
+
+    assertThrows(ResponseStatusException.class, () -> groupService.leaveGroup(2L, "token"));
+  }
+
+
+  @Test
+  public void updateGroup_validOwner_updatesName() {
+    Group existingGroup = new Group();
+    existingGroup.setId(2L);
+    existingGroup.setName("Test Group");
+    existingGroup.setPassword("secret");
+    existingGroup.setCreatedBy("creator");
+
+    when(groupRepository.findById(2L)).thenReturn(Optional.of(existingGroup));
+
+    GroupPutDTO dto = new GroupPutDTO();
+    dto.setName("New Name");
+
+    Group result = groupService.updateGroup(2L, dto, "token");
+
+    assertEquals("New Name", result.getName());
+  }
+
+  @Test
+  public void updateGroup_validOwner_updatesPassword() {
+    Group existingGroup = new Group();
+    existingGroup.setId(2L);
+    existingGroup.setName("Test Group");
+    existingGroup.setPassword("secret");
+    existingGroup.setCreatedBy("creator");
+
+    when(groupRepository.findById(2L)).thenReturn(Optional.of(existingGroup));
+
+    GroupPutDTO dto = new GroupPutDTO();
+    dto.setPassword("newpass");
+
+    groupService.updateGroup(2L, dto, "token");
+
+    verify(groupRepository).save(existingGroup);
+  }
+
+  @Test
+  public void updateGroup_invalidToken_throwsUnauthorized() {
+    when(userRepository.findByToken("bad")).thenReturn(null);
+
+    GroupPutDTO dto = new GroupPutDTO();
+    dto.setName("New Name");
+
+    assertThrows(ResponseStatusException.class, () -> groupService.updateGroup(2L, dto, "bad"));
+  }
+
+  @Test
+  public void updateGroup_groupNotFound_throwsNotFound() {
+    when(groupRepository.findById(99L)).thenReturn(Optional.empty());
+
+    GroupPutDTO dto = new GroupPutDTO();
+    dto.setName("New Name");
+
+    assertThrows(ResponseStatusException.class, () -> groupService.updateGroup(99L, dto, "token"));
+  }
+
+  @Test
+  public void updateGroup_notOwner_throwsForbidden() {
+    Group existingGroup = new Group();
+    existingGroup.setId(2L);
+    existingGroup.setName("Test Group");
+    existingGroup.setPassword("secret");
+    existingGroup.setCreatedBy("other");
+
+    when(groupRepository.findById(2L)).thenReturn(Optional.of(existingGroup));
+
+    GroupPutDTO dto = new GroupPutDTO();
+    dto.setName("New Name");
+
+    assertThrows(ResponseStatusException.class, () -> groupService.updateGroup(2L, dto, "token"));
+  }
+
+
+  @Test
+  public void deleteGroup_validOwner_deletesGroup() {
+    Group existingGroup = new Group();
+    existingGroup.setId(2L);
+    existingGroup.setName("Test Group");
+    existingGroup.setPassword("secret");
+    existingGroup.setCreatedBy("creator");
+
+    when(groupRepository.findById(2L)).thenReturn(Optional.of(existingGroup));
+
+    groupService.deleteGroup(2L, "token");
+
+    verify(groupRepository).delete(existingGroup);
+  }
+
+  @Test
+  public void deleteGroup_invalidToken_throwsUnauthorized() {
+    when(userRepository.findByToken("bad")).thenReturn(null);
+
+    assertThrows(ResponseStatusException.class, () -> groupService.deleteGroup(2L, "bad"));
+  }
+
+  @Test
+  public void deleteGroup_groupNotFound_throwsNotFound() {
+    when(groupRepository.findById(99L)).thenReturn(Optional.empty());
+
+    assertThrows(ResponseStatusException.class, () -> groupService.deleteGroup(99L, "token"));
+  }
+
+  @Test
+  public void deleteGroup_notOwner_throwsForbidden() {
+    Group existingGroup = new Group();
+    existingGroup.setId(2L);
+    existingGroup.setName("Test Group");
+    existingGroup.setPassword("secret");
+    existingGroup.setCreatedBy("other");
+
+    when(groupRepository.findById(2L)).thenReturn(Optional.of(existingGroup));
+
+    assertThrows(ResponseStatusException.class, () -> groupService.deleteGroup(2L, "token"));
   }
 }


### PR DESCRIPTION
- implemented backend logic for group habit progress by adjusting group service, controller, DTOs and repo. -> closes #148 
- added completedHabits and totalHabits fields to the GET /groups response -> now we get all habits for each group member so we can display the overall group habit progress -> accountability
- added group management with new endpoints. group members (not owner) can now also leave a group. group owners can update group (rename and set new password) or delete group so it will disappear for every group member.
- added tests for group business logic (service, character, repo + DTO) and also for achievements.